### PR TITLE
Feature/cancelled event mail

### DIFF
--- a/src/Email/CalendarInvite.fs
+++ b/src/Email/CalendarInvite.fs
@@ -57,7 +57,7 @@ module CalendarInvite =
               participantEmail.Unwrap participantEmail.Unwrap
           sprintf "SUMMARY;LANGUAGE=nb-NO:%s" event.Title.Unwrap
           sprintf "DESCRIPTION;LANGUAGE=nb-NO:%s"
-              (message.Replace("<br>", "\\n "))
+              (message.Replace("<br>", "\n"))
           sprintf "X-ALT-DESC;FMTTYPE=text/html:%s" event.Description.Unwrap
           sprintf "LOCATION;LANGUAGE=nb-NO:%s" event.Location.Unwrap
 

--- a/src/Events/Handlers.fs
+++ b/src/Events/Handlers.fs
@@ -34,8 +34,16 @@ module Handlers =
 
     let deleteEvent id =
         result {
-            for result in Service.deleteEvent (Id id) do
-                return result
+            for messageToParticipants in getBody<string> do
+                for participants in Participant.Service.getParticipantsForEvent
+                                        (Id id) do
+                    for event in Service.getEvent (Id id) do
+
+                        yield Participant.Service.sendCancellationMailToParticipants
+                                  messageToParticipants participants event
+
+                        for result in Service.deleteEvent (Id id) do
+                            return result
         }
 
     let updateEvent id =

--- a/src/Events/Handlers.fs
+++ b/src/Events/Handlers.fs
@@ -35,7 +35,6 @@ module Handlers =
     let deleteEvent id =
         result {
             for result in Service.deleteEvent (Id id) do
-                yield commitTransaction
                 return result
         }
 
@@ -45,7 +44,6 @@ module Handlers =
                 let! domainModel = writeToDomain id writeModel
 
                 for updatedEvent in Service.updateEvent (Id id) domainModel do
-                    yield commitTransaction
                     return domainToView updatedEvent
         }
 

--- a/src/Events/Service.fs
+++ b/src/Events/Service.fs
@@ -84,5 +84,6 @@ module Service =
 
                 let! event = events |> queryEventBy id
                 repo.del event
+
                 return eventSuccessfullyDeleted id
         }

--- a/src/Events/Service.fs
+++ b/src/Events/Service.fs
@@ -54,7 +54,8 @@ module Service =
           From = EmailAddress config.noReplyEmail
           To = event.OrganizerEmail
           CalendarInvite =
-              createCalendarAttachment event event.OrganizerEmail message }
+              createCalendarAttachment
+                  (event, event.OrganizerEmail, message, Create) }
 
     let private sendNewlyCreatedEventMail createEditUrl (event: Event) =
         result {

--- a/src/Participants/Service.fs
+++ b/src/Participants/Service.fs
@@ -28,8 +28,11 @@ module Service =
           sprintf "Hilsen %s i Bekk" event.OrganizerEmail.Unwrap ]
         |> String.concat "<br>" // Sendgrid formats to HTML, \n does not work
 
-    let private createEmail createCancelUrl (participant: Participant)
-        (event: Event) =
+    let createNewParticipantMail
+        createCancelUrl
+        (event: Event)
+        (participant: Participant)
+        =
         let message = inviteMessage (createCancelUrl participant) event
         { Subject = event.Title.Unwrap
           Message = message
@@ -38,20 +41,12 @@ module Service =
           CalendarInvite =
               createCalendarAttachment event participant.Email message }
 
-    let private sendEventEmail createCancelUrl (participant: Participant) =
-        result {
-            for event in Event.Service.getEvent participant.EventId do
-                let mail = createEmail createCancelUrl participant event
-                yield Service.sendMail mail
-        }
-
-    let registerParticipant createCancelUrl registration =
+    let registerParticipant createMail registration =
         result {
 
             for participant in repo.create registration do
 
-                yield sendEventEmail createCancelUrl participant
-
+                yield Service.sendMail (createMail participant)
                 return participant
         }
 

--- a/src/Participants/Service.fs
+++ b/src/Participants/Service.fs
@@ -41,6 +41,18 @@ module Service =
           CalendarInvite =
               createCalendarAttachment event participant.Email message }
 
+    let private createCancelledEventMail
+        message
+        (event: Event)
+        (participant: Participant)
+        =
+        { Subject = "CANCELLED"
+          Message = message
+          From = event.OrganizerEmail
+          To = participant.Email
+          CalendarInvite =
+              createCalendarAttachment event participant.Email message }
+
     let registerParticipant createMail registration =
         result {
 
@@ -86,3 +98,16 @@ module Service =
 
                 return participationSuccessfullyDeleted (eventId, email)
         }
+
+    let sendCancellationMailToParticipants
+        messageToParticipants
+        participants
+        event
+        ctx
+        =
+        let sendMailToParticipant participant =
+            Service.sendMail
+                (createCancelledEventMail messageToParticipants event
+                     participant) ctx
+        participants |> Seq.iter sendMailToParticipant
+        Ok()

--- a/src/Participants/Service.fs
+++ b/src/Participants/Service.fs
@@ -39,19 +39,21 @@ module Service =
           From = event.OrganizerEmail
           To = participant.Email
           CalendarInvite =
-              createCalendarAttachment event participant.Email message }
+              createCalendarAttachment
+                  (event, participant.Email, message, Create) }
 
     let private createCancelledEventMail
         message
         (event: Event)
         (participant: Participant)
         =
-        { Subject = "CANCELLED"
+        { Subject = sprintf "Avlyst: %s" event.Title.Unwrap
           Message = message
           From = event.OrganizerEmail
           To = participant.Email
           CalendarInvite =
-              createCalendarAttachment event participant.Email message }
+              createCalendarAttachment
+                  (event, participant.Email, message, Cancel) }
 
     let registerParticipant createMail registration =
         result {

--- a/src/Participants/Service.fs
+++ b/src/Participants/Service.fs
@@ -43,12 +43,12 @@ module Service =
                   (event, participant.Email, message, Create) }
 
     let private createCancelledEventMail
-        message
+        (message: string)
         (event: Event)
         (participant: Participant)
         =
         { Subject = sprintf "Avlyst: %s" event.Title.Unwrap
-          Message = message
+          Message = message.Replace("\n", "<br>")
           From = event.OrganizerEmail
           To = participant.Email
           CalendarInvite =

--- a/src/bekk-arrangement-svc.fsproj
+++ b/src/bekk-arrangement-svc.fsproj
@@ -58,13 +58,18 @@
 
   <ItemGroup>
     <Compile Include="Config.fs" />
+
     <Compile Include="LanguageExtensions\Validation.fs" />
     <Compile Include="LanguageExtensions\ResultComputationExpression.fs" /> 
+
     <Compile Include="Common\UserMessage.fs" />
+
     <Compile Include="Database\DbContext.fs" />
     <Compile Include="Database\Repo.fs" />
+
     <Compile Include="Common\Http.fs" /> 
     <Compile Include="Common\Auth.fs" />
+
     <Compile Include="DomainTypes\DateTime.fs" />
     <Compile Include="DomainTypes\TimeStamp.fs" />
     <Compile Include="DomainTypes\Utils.fs" />
@@ -72,22 +77,30 @@
     <Compile Include="DomainTypes\Event.fs" />
     <Compile Include="DomainTypes\Participant.fs" /> 
     <Compile Include="DomainTypes\DomainModels.fs" />
+
     <Compile Include="Email\SendgridApiModels.fs" />
     <Compile Include="Email\Models.fs" />
     <Compile Include="Email\Service.fs" />
     <Compile Include="Email\CalendarInvite.fs" />
+
     <Compile Include="Events\UserMessages.fs" />
-    <Compile Include="Events\Models.fs" />
-    <Compile Include="Events\Queries.fs" />
-    <Compile Include="Events\Service.fs" />
-    <Compile Include="Events\Authorization.fs" />
-    <Compile Include="Events\Handlers.fs" />
     <Compile Include="Participants\UserMessages.fs" />
+
+    <Compile Include="Events\Models.fs" />
     <Compile Include="Participants\Models.fs" />
+
+    <Compile Include="Events\Queries.fs" />
     <Compile Include="Participants\Queries.fs" />
+
+    <Compile Include="Events\Service.fs" />
     <Compile Include="Participants\Service.fs" />
+
+    <Compile Include="Events\Authorization.fs" />
     <Compile Include="Participants\Authorization.fs" />
+
+    <Compile Include="Events\Handlers.fs" />
     <Compile Include="Participants\Handlers.fs" />
+
     <Compile Include="Health\Health.fs" />
     <Compile Include="Logging.fs" /> 
     <Compile Include="Program.fs" />


### PR DESCRIPTION
Denne endringa sender mail til alle participants på eit arrangement som blir sletta.

Dette krever at calendar-invite koden støtter både ein slags `Create` modus og ein `Cancel` modus. Det er ikkje sikkert denne er 100% riktig, men det tenker eg vi tester mot alle klienter og sånn etterkvart, det ser ut til å funke i min outlook i alle fall. Her er infrastrukturen på plass til å mekke det som trengs.

Denne PRen refactorer litt strukturen på ting også, mest notably flytter vi alle dependenciene i fsproj slik at alle handlers er i samme "layer", og alle servicer i samme. Dvs. at alle handlers kan bruke alle servicer, men servicer i utgangspunktet ikkje snakker med kvarandre.

I tillegg har eg flytta commit-transaction-kallet til slutten av handleren. Det skal egt. ikkje vere naudsynt å kalle den manuelt nokon plass. Trur dette berre har vore ein glipp frå tidligare, ettersom dette no speiler rollback-transaction.