### PR TITLE
Only show participant info for users with correct Edit token

### DIFF
--- a/src/DomainTypes/Event.fs
+++ b/src/DomainTypes/Event.fs
@@ -93,3 +93,10 @@ type ParticipantQuestion =
         [ validateMaxLength 500
               (BadInput "Spørsmål til deltaker kan ha maks 500 tegn") ]
         |> validateAll ParticipantQuestion participantQuestion
+
+type NumberOfParticipants = 
+    | NumberOfParticipants of int
+
+    member this.Unwrap =
+        match this with
+        | NumberOfParticipants count -> count

--- a/src/Events/Authorization.fs
+++ b/src/Events/Authorization.fs
@@ -26,6 +26,8 @@ module Authorization =
             else
                 return! [ AccessDenied $"You are trying to edit an event (id {eventId}) which you did not create"] |> Error
         }
+    
+    let userCanSeeParticipants = userCreatedEvent
 
     let userCanEditEvent eventId =
         anyOf

--- a/src/Events/Validation.fs
+++ b/src/Events/Validation.fs
@@ -9,7 +9,7 @@ open ArrangementService.ResultComputationExpression
 module Validation =
     let assertNumberOfParticipantsLessThanOrEqualMax (event:Event) =
         result {
-            let! numberOfParticipants = Participant.Queries.getNumberOfParticipants event.Id
+            let! numberOfParticipants = Participant.Queries.getNumberOfParticipantsByEvent event.Id
             if numberOfParticipants <= event.MaxParticipants.Unwrap then return () 
             else return! Error [UserMessages.invalidMaxParticipantValue] 
         }

--- a/src/Events/Validation.fs
+++ b/src/Events/Validation.fs
@@ -9,7 +9,7 @@ open ArrangementService.ResultComputationExpression
 module Validation =
     let assertNumberOfParticipantsLessThanOrEqualMax (event:Event) =
         result {
-            let! numberOfParticipants = Participant.Queries.getNumberOfParticipantsByEvent event.Id
+            let! numberOfParticipants = Participant.Queries.getNumberOfParticipantsForEvent event.Id
             if numberOfParticipants <= event.MaxParticipants.Unwrap then return () 
             else return! Error [UserMessages.invalidMaxParticipantValue] 
         }

--- a/src/Participants/Handlers.fs
+++ b/src/Participants/Handlers.fs
@@ -85,9 +85,9 @@ module Handlers =
                              None }
         }
     
-    let getNumberOfParticipantsByEvent id =
+    let getNumberOfParticipantsForEvent id =
         result {
-            let! count = Service.getNumberOfParticipants (Event.Id id)
+            let! count = Service.getNumberOfParticipantsForEvent (Event.Id id)
             return count.Unwrap
         }
 
@@ -99,7 +99,7 @@ module Handlers =
                             check (userCanSeeParticipants eventId)
                             >=> (handle << getParticipantsForEvent) eventId)
                         routef "/events/%O/participants/count" (fun eventId ->
-                            (handle << getNumberOfParticipantsByEvent) eventId)
+                            (handle << getNumberOfParticipantsForEvent) eventId)
                         routef "/participants/%s/events"
                             (handle << getParticipationsForParticipant) ]
               DELETE

--- a/src/Participants/Handlers.fs
+++ b/src/Participants/Handlers.fs
@@ -12,6 +12,7 @@ open System.Web
 open System
 open ArrangementService.DomainModels
 open ArrangementService.Config
+open ArrangementService.Event.Authorization
 
 module Handlers =
 
@@ -88,8 +89,9 @@ module Handlers =
         choose
             [ GET
               >=> choose
-                      [ routef "/events/%O/participants"
-                            (handle << getParticipantsForEvent)
+                      [ routef "/events/%O/participants" (fun eventId ->
+                            check (userCanSeeParticipants eventId)
+                            >=> (handle << getParticipantsForEvent) eventId)
                         routef "/participants/%s/events"
                             (handle << getParticipationsForParticipant) ]
               DELETE

--- a/src/Participants/Handlers.fs
+++ b/src/Participants/Handlers.fs
@@ -98,8 +98,8 @@ module Handlers =
                       [ routef "/events/%O/participants" (fun eventId ->
                             check (userCanSeeParticipants eventId)
                             >=> (handle << getParticipantsForEvent) eventId)
-                        routef "/events/%O/participants/count" (fun eventId ->
-                            (handle << getNumberOfParticipantsForEvent) eventId)
+                        routef "/events/%O/participants/count" 
+                            (handle << getNumberOfParticipantsForEvent)
                         routef "/participants/%s/events"
                             (handle << getParticipationsForParticipant) ]
               DELETE

--- a/src/Participants/Handlers.fs
+++ b/src/Participants/Handlers.fs
@@ -84,6 +84,12 @@ module Handlers =
                          else
                              None }
         }
+    
+    let getNumberOfParticipantsByEvent id =
+        result {
+            let! count = Service.getNumberOfParticipants (Event.Id id)
+            return count.Unwrap
+        }
 
     let routes: HttpHandler =
         choose
@@ -92,6 +98,8 @@ module Handlers =
                       [ routef "/events/%O/participants" (fun eventId ->
                             check (userCanSeeParticipants eventId)
                             >=> (handle << getParticipantsForEvent) eventId)
+                        routef "/events/%O/participants/count" (fun eventId ->
+                            (handle << getNumberOfParticipantsByEvent) eventId)
                         routef "/participants/%s/events"
                             (handle << getParticipationsForParticipant) ]
               DELETE

--- a/src/Participants/Queries.fs
+++ b/src/Participants/Queries.fs
@@ -53,7 +53,7 @@ module Queries =
         |> Database.runSelectQuery ctx
         |> Seq.map Models.dbToDomain
     
-    let getNumberOfParticipantsByEvent (eventId: Event.Id) (ctx: HttpContext) =
+    let getNumberOfParticipantsForEvent (eventId: Event.Id) (ctx: HttpContext) =
         select { table participantsTable
                  count "*" "Value"
                  where (eq "EventId" eventId.Unwrap)

--- a/src/Participants/Queries.fs
+++ b/src/Participants/Queries.fs
@@ -53,7 +53,7 @@ module Queries =
         |> Database.runSelectQuery ctx
         |> Seq.map Models.dbToDomain
     
-    let getNumberOfParticipants (eventId: Event.Id) (ctx: HttpContext) =
+    let getNumberOfParticipantsByEvent (eventId: Event.Id) (ctx: HttpContext) =
         select { table participantsTable
                  count "*" "Value"
                  where (eq "EventId" eventId.Unwrap)

--- a/src/Participants/Service.fs
+++ b/src/Participants/Service.fs
@@ -4,6 +4,7 @@ open ArrangementService
 
 open ResultComputationExpression
 open ArrangementService.Email
+open ArrangementService.Event
 open CalendarInvite
 open UserMessages
 open Models
@@ -218,3 +219,9 @@ module Service =
         participants |> Seq.iter sendMailToParticipant
 
         Ok()
+    
+    let getNumberOfParticipants eventID =
+        result {
+            let! count = Queries.getNumberOfParticipantsByEvent eventID
+            return NumberOfParticipants count
+        }

--- a/src/Participants/Service.fs
+++ b/src/Participants/Service.fs
@@ -220,8 +220,8 @@ module Service =
 
         Ok()
     
-    let getNumberOfParticipants eventID =
+    let getNumberOfParticipantsForEvent eventId =
         result {
-            let! count = Queries.getNumberOfParticipantsByEvent eventID
+            let! count = Queries.getNumberOfParticipantsForEvent eventId
             return NumberOfParticipants count
         }


### PR DESCRIPTION
Før kunne man se all info om alle deltakere på et arrangement. Nå er det kun de som har tilgang til Edit-token(de som lagde arrangementet, og eventuelt andre som har fått tak i den) mulighet til å se navn og epost. 

Det er også lagt til et endepunkt som returnerer antall deltagere på et arrangement, uten all informasjonen om deltagerene. I fremtiden burde kanskje denne dataen være en del av Event objektet. 

Ennå ikke blitt testet med frontend 

https://trello.com/c/XqKiY0On/998-sjekk-at-liste-over-p%C3%A5meldte-bare-er-tilgjengelig-for-arrang%C3%B8r