### PR TITLE
Fix unintended sideeffect when updating an event for the second time

### DIFF
--- a/src/Events/Handlers.fs
+++ b/src/Events/Handlers.fs
@@ -48,13 +48,10 @@ module Handlers =
             return result
         }
 
-    let updateEvent id =
+    let updateEvent (id:Key) =
         result {
             let! writeModel = getBody<WriteModel>
-            let! domainModel = writeToDomain id writeModel |> ignoreContext
-
-            
-            let! updatedEvent = Service.updateEvent (Id id) domainModel
+            let! updatedEvent = Service.updateEvent (Id id) writeModel
             return domainToView updatedEvent
         }
 

--- a/src/Events/Models.fs
+++ b/src/Events/Models.fs
@@ -72,6 +72,7 @@ module Models =
     let writeToDomain
         (id: Key)
         (writeModel: WriteModel)
+        (editToken: Guid)
         : Result<Event, UserMessage list>
         =
         Ok Event.Create 
@@ -84,7 +85,7 @@ module Models =
         <*> MaxParticipants.Parse writeModel.MaxParticipants
         <*> validateDateRange writeModel.StartDate writeModel.EndDate
         <*> OpenForRegistrationTime.Parse writeModel.OpenForRegistrationTime
-        <*> (Guid.NewGuid() |> Ok)
+        <*> Ok editToken
         <*> ParticipantQuestion.Parse writeModel.ParticipantQuestion
         <*> (writeModel.HasWaitingList |> Ok)
 

--- a/src/Events/Service.fs
+++ b/src/Events/Service.fs
@@ -7,6 +7,7 @@ open UserMessages
 open Validation
 open ArrangementService.DomainModels
 open Http
+open Models
 
 module Service =
 
@@ -59,11 +60,14 @@ module Service =
         }
 
 
-    let updateEvent id event =
+    let updateEvent (id:Event.Id) writeModel =
         result {
-            do! assertNumberOfParticipantsLessThanOrEqualMax event
-            do! Queries.updateEvent id event
-            return event 
+            let! editToken = Queries.queryEditTokenByEventId id
+            let! newEvent = writeToDomain id.Unwrap writeModel editToken |> ignoreContext
+
+            do! assertNumberOfParticipantsLessThanOrEqualMax newEvent
+            do! Queries.updateEvent newEvent
+            return newEvent 
         }
     
     let deleteEvent id =


### PR DESCRIPTION
writeToDomain is called everytime updateEvent is done and unfortunately has a side effect of generating a new EditToken. Now this is given as an argument