### PR TITLE
Add endpoint for checking waitinglist spot

### DIFF
--- a/src/Participants/Handlers.fs
+++ b/src/Participants/Handlers.fs
@@ -90,6 +90,8 @@ module Handlers =
             let! count = Service.getNumberOfParticipantsForEvent (Event.Id id)
             return count.Unwrap
         }
+    
+    let getWaitinglistSpot (eventId, email) = Service.getWaitinglistSpot (Event.Id eventId) (EmailAddress email) 
 
     let routes: HttpHandler =
         choose
@@ -100,6 +102,8 @@ module Handlers =
                             >=> (handle << getParticipantsForEvent) eventId)
                         routef "/events/%O/participants/count" 
                             (handle << getNumberOfParticipantsForEvent)
+                        routef "/events/%O/participants/%s/waitinglist-spot" (fun (eventId, email) ->
+                            (handle << getWaitinglistSpot) (eventId, email))
                         routef "/participants/%s/events"
                             (handle << getParticipationsForParticipant) ]
               DELETE

--- a/src/Participants/Queries.fs
+++ b/src/Participants/Queries.fs
@@ -49,6 +49,7 @@ module Queries =
     let queryParticipantsByEventId (eventId: Event.Id) ctx: Participant seq =
         select { table participantsTable
                  where (eq "EventId" eventId.Unwrap)
+                 orderBy "RegistrationTime" Asc
                }
         |> Database.runSelectQuery ctx
         |> Seq.map Models.dbToDomain

--- a/src/Participants/Service.fs
+++ b/src/Participants/Service.fs
@@ -242,5 +242,5 @@ module Service =
             return! match (waitingListIndex,isAttending) with
                     | (Some x, _) -> Ok (x+1) 
                     | (None, true) -> Ok 0 
-                    | (None , false) -> Error [ UserMessages.participantNotFound email ]
+                    | (None , false) -> Error [participantNotFound email ]
         }


### PR DESCRIPTION
Ser etter tilbakemelding på noen ting:

* navnet på endepunkt er kanskje ikke helt optimalt, https://stackoverflow.com/questions/20400250/email-addresses-inside-url. Se kommentaren min for et forslag til endring

* Endepunktet håndterer 3 muligheter:
    - Du er på venteliste, da får du tilbake hvor du er i køen
    - Du er ikke på venteliste, men deltar på arrangementet, da får du 0
    - Du deltar ikke på eventet, du får en feilmelding. (Dette skal jo aldri skje, så det er en fint å ha en feilmelding siden det kan avdekke feil i frontend)

Co-authored-by: Tarjei Skjærset <tskj@tarjei.org>