### PR TITLE
Add cancel event feature

### DIFF
--- a/migration/Migrations/17-isCancelled.sql
+++ b/migration/Migrations/17-isCancelled.sql
@@ -1,0 +1,4 @@
+USE [arrangement-db];
+
+ALTER TABLE [Events]
+ADD IsCancelled BIT NOT NULL DEFAULT 0;

--- a/src/DomainTypes/DomainModels.fs
+++ b/src/DomainTypes/DomainModels.fs
@@ -24,9 +24,10 @@ type Event =
       EditToken: Guid
       ParticipantQuestion: Event.ParticipantQuestion
       HasWaitingList: bool
+      IsCancelled: bool
     }
     static member Create =
-        fun id title description location organizerName organizerEmail maxParticipants (startDate, endDate) openForRegistrationTime editToken participantQuestion hasWaitingList ->
+        fun id title description location organizerName organizerEmail maxParticipants (startDate, endDate) openForRegistrationTime editToken participantQuestion hasWaitingList isCancelled->
             { Id = id
               Title = title
               Description = description
@@ -40,6 +41,7 @@ type Event =
               EditToken = editToken
               ParticipantQuestion = participantQuestion
               HasWaitingList = hasWaitingList
+              IsCancelled = isCancelled
             }
 
 type Participant =

--- a/src/Events/Authorization.fs
+++ b/src/Events/Authorization.fs
@@ -35,9 +35,8 @@ module Authorization =
 
     let userCanSeeParticipants = userCanEditEvent
 
-    let eventHasOpenedForRegistration eventId =
+    let eventHasOpenedForRegistration (event:DomainModels.Event) =
         result {
-            let! event = Service.getEvent (Id eventId)
             let openDateTime =
                 DateTimeOffset.FromUnixTimeMilliseconds
                     event.OpenForRegistrationTime.Unwrap
@@ -48,9 +47,8 @@ module Authorization =
                 return! [ AccessDenied $"Arrangementet åpner for påmelding {openDateTime.ToLocalTime}" ] |> Error
         }
 
-    let eventHasNotPassed eventId =
+    let eventHasNotPassed (event:DomainModels.Event) =
         result {
-            let! event = Service.getEvent (Id eventId)
             if event.EndDate > now() then
                 return ()
             else

--- a/src/Events/Handlers.fs
+++ b/src/Events/Handlers.fs
@@ -10,10 +10,15 @@ open ArrangementService.Config
 open ArrangementService.Email
 open Authorization
 
+open Microsoft.AspNetCore.Http
 open Giraffe
 open System.Web
 
 module Handlers =
+
+    type RemoveEvent = 
+        | Cancel
+        | Delete
 
     let getEvents: Handler<ViewModel list> =
         result {
@@ -33,18 +38,21 @@ module Handlers =
             return domainToView event
         }
 
-    let deleteEvent id =
+        
+    let deleteOrCancelEvent (removeEventType:RemoveEvent) id : (HttpContext -> Result<string,UserMessage.UserMessage list>)=
         result {
             let! messageToParticipants = getBody<string>
             let! event = Service.getEvent (Id id)
             let! participants = Participant.Service.getParticipantsForEvent event
-            
+
             let! config = getConfig >> Ok
 
             yield Participant.Service.sendCancellationMailToParticipants
                       messageToParticipants (EmailAddress config.noReplyEmail) participants.attendees event
 
-            let! result = Service.deleteEvent (Id id)
+            let! result =  match removeEventType with 
+                            | Cancel -> Service.cancelEvent event
+                            | Delete -> Service.deleteEvent (Id id)
             return result
         }
 
@@ -73,6 +81,9 @@ module Handlers =
             return domainToViewWithEditInfo newEvent
         }
 
+    let deleteEvent = deleteOrCancelEvent Delete
+    let cancelEvent = deleteOrCancelEvent Cancel
+
     let routes: HttpHandler =
         choose
             [ GET
@@ -85,7 +96,11 @@ module Handlers =
               >=> choose
                       [ routef "/events/%O" (fun id ->
                             check (userCanEditEvent id)
-                            >=> (handle << deleteEvent) id) ]
+                            >=> (handle << deleteEvent) id)
+                        routef "/events/%O/cancel" (fun id -> 
+                            check (userCanEditEvent id)
+                            >=> (handle << cancelEvent) id)
+                        ]
               PUT
               >=> choose
                       [ routef "/events/%O" (fun id ->

--- a/src/Events/Handlers.fs
+++ b/src/Events/Handlers.fs
@@ -96,10 +96,10 @@ module Handlers =
               >=> choose
                       [ routef "/events/%O" (fun id ->
                             check (userCanEditEvent id)
-                            >=> (handle << deleteEvent) id)
-                        routef "/events/%O/cancel" (fun id -> 
-                            check (userCanEditEvent id)
                             >=> (handle << cancelEvent) id)
+                        routef "/events/%O/delete" (fun id -> 
+                            check (userCanEditEvent id)
+                            >=> (handle << deleteEvent) id)
                         ]
               PUT
               >=> choose

--- a/src/Events/Models.fs
+++ b/src/Events/Models.fs
@@ -29,6 +29,7 @@ type DbModel =
       OpenForRegistrationTime: int64
       ParticipantQuestion: string 
       HasWaitingList: bool 
+      IsCancelled: bool 
       EditToken: Guid
     }
 
@@ -45,6 +46,7 @@ type ViewModel =
       OpenForRegistrationTime: int64
       ParticipantQuestion: string 
       HasWaitingList: bool 
+      IsCancelled: bool 
     }
 
 type ViewModelWithEditToken =
@@ -65,6 +67,7 @@ type WriteModel =
       editUrlTemplate: string
       ParticipantQuestion: string 
       HasWaitingList: bool 
+      IsCancelled: bool 
     }
 
 module Models =
@@ -88,6 +91,7 @@ module Models =
         <*> Ok editToken
         <*> ParticipantQuestion.Parse writeModel.ParticipantQuestion
         <*> (writeModel.HasWaitingList |> Ok)
+        <*> (writeModel.IsCancelled |> Ok)
 
     let dbToDomain (dbRecord: DbModel): Event =
         { Id = Id dbRecord.Id
@@ -104,6 +108,7 @@ module Models =
           EditToken = dbRecord.EditToken
           ParticipantQuestion = ParticipantQuestion dbRecord.ParticipantQuestion
           HasWaitingList = dbRecord.HasWaitingList
+          IsCancelled = dbRecord.IsCancelled
         }
         
     let domainToDb (domainModel: Event): DbModel =
@@ -122,6 +127,7 @@ module Models =
           EditToken = domainModel.EditToken
           ParticipantQuestion = domainModel.ParticipantQuestion.Unwrap
           HasWaitingList = domainModel.HasWaitingList
+          IsCancelled = domainModel.IsCancelled
         }
         
 
@@ -138,6 +144,7 @@ module Models =
           OpenForRegistrationTime = domainModel.OpenForRegistrationTime.Unwrap
           ParticipantQuestion = domainModel.ParticipantQuestion.Unwrap
           HasWaitingList = domainModel.HasWaitingList 
+          IsCancelled = domainModel.IsCancelled 
         }
 
     let domainToViewWithEditInfo (event: Event): ViewModelWithEditToken =

--- a/src/Events/Models.fs
+++ b/src/Events/Models.fs
@@ -67,7 +67,6 @@ type WriteModel =
       editUrlTemplate: string
       ParticipantQuestion: string 
       HasWaitingList: bool 
-      IsCancelled: bool 
     }
 
 module Models =
@@ -76,6 +75,7 @@ module Models =
         (id: Key)
         (writeModel: WriteModel)
         (editToken: Guid)
+        (isCancelled: bool)
         : Result<Event, UserMessage list>
         =
         Ok Event.Create 
@@ -91,7 +91,7 @@ module Models =
         <*> Ok editToken
         <*> ParticipantQuestion.Parse writeModel.ParticipantQuestion
         <*> (writeModel.HasWaitingList |> Ok)
-        <*> (writeModel.IsCancelled |> Ok)
+        <*> Ok isCancelled
 
     let dbToDomain (dbRecord: DbModel): Event =
         { Id = Id dbRecord.Id

--- a/src/Events/Queries.fs
+++ b/src/Events/Queries.fs
@@ -19,7 +19,7 @@ module Queries =
 
     let createEvent (event: WriteModel) =
         result {
-            let! event = Models.writeToDomain (Guid.NewGuid()) event (Guid.NewGuid()) |> ignoreContext
+            let! event = Models.writeToDomain (Guid.NewGuid()) event (Guid.NewGuid()) false |> ignoreContext
             let dbModel = Models.domainToDb event
             do! insert { table eventsTable
                          value dbModel
@@ -60,12 +60,6 @@ module Queries =
        |> function
        | Some event -> Ok <| Models.dbToDomain event
        | None -> Error [ UserMessages.eventNotFound eventId ]
-
-    let queryEditTokenByEventId (id:Event.Id) =
-        result {
-            let! event = queryEventByEventId id
-            return event.EditToken
-        }
 
     let queryEventsOrganizedByEmail (organizerEmail: EmailAddress) ctx: Event seq =
         select { table eventsTable

--- a/src/Events/Service.fs
+++ b/src/Events/Service.fs
@@ -76,6 +76,12 @@ module Service =
             do! Queries.updateEvent newEvent
             return newEvent 
         }
+
+    let cancelEvent event =
+        result {
+            do! Queries.updateEvent {event with IsCancelled=true}
+            return eventSuccessfullyDeleted id
+        }
     
     let deleteEvent id =
         result {

--- a/src/Events/Service.fs
+++ b/src/Events/Service.fs
@@ -80,7 +80,7 @@ module Service =
     let cancelEvent event =
         result {
             do! Queries.updateEvent {event with IsCancelled=true}
-            return eventSuccessfullyDeleted id
+            return eventSuccessfullyCancelled event.Title
         }
     
     let deleteEvent id =

--- a/src/Events/UserMessages.fs
+++ b/src/Events/UserMessages.fs
@@ -10,5 +10,7 @@ module UserMessages =
         $"Kan ikke oppdatere event {id}" |> NotFound
     let eventSuccessfullyDeleted id: string =
         $"Event {id} blei sletta"
+    let eventSuccessfullyCancelled title: string =
+        $"Arrangement: '{title}' blei avlyst. Epost har blitt sendt til alle deltagere"
     let invalidMaxParticipantValue : UserMessage = 
         $"Du kan ikke sette maks deltagere til lavere enn antall som allerede deltar" |> BadInput

--- a/src/Participants/Authorization.fs
+++ b/src/Participants/Authorization.fs
@@ -34,10 +34,8 @@ module Authorization =
             [ userHasCancellationToken eventIdAndEmail
               isAdmin ]
 
-    let eventHasAvailableSpots eventId =
+    let eventHasAvailableSpots (event:DomainModels.Event) =
         result {
-            let! event = Event.Service.getEvent (Event.Id eventId)
-            
             let hasWaitingList = event.HasWaitingList
             let maxParticipants = event.MaxParticipants.Unwrap
             let! participants = Service.getParticipantsForEvent event
@@ -47,4 +45,19 @@ module Authorization =
                 return ()
             else
                 return! [ AccessDenied "The event is full" ] |> Error
+        }
+    let eventIsNotCancelled (event:DomainModels.Event) =  
+        if event.IsCancelled then
+            Error [AccessDenied "The event is cancelled"]
+        else
+            Ok ()
+
+    let oneCanParticipateOnEvent eventIdKey =
+        let eventId = Event.Id eventIdKey
+        result {
+            let! event = Event.Service.getEvent eventId
+            do! eventHasAvailableSpots event
+            do! Event.Authorization.eventHasNotPassed event
+            do! Event.Authorization.eventHasOpenedForRegistration event
+            do! eventIsNotCancelled event |> ignoreContext
         }

--- a/src/Participants/Authorization.fs
+++ b/src/Participants/Authorization.fs
@@ -44,11 +44,11 @@ module Authorization =
             then
                 return ()
             else
-                return! [ AccessDenied "The event is full" ] |> Error
+                return! [ AccessDenied "Arrangementet er fullt" ] |> Error
         }
     let eventIsNotCancelled (event:DomainModels.Event) =  
         if event.IsCancelled then
-            Error [AccessDenied "The event is cancelled"]
+            Error [AccessDenied "Arrangementet er avlyst"]
         else
             Ok ()
 

--- a/src/Participants/Handlers.fs
+++ b/src/Participants/Handlers.fs
@@ -115,8 +115,6 @@ module Handlers =
               POST
               >=> choose
                       [ routef "/events/%O/participants/%s" (fun (eventId: Guid, email) ->
-                            (check (eventHasAvailableSpots eventId)
-                            >=> check (eventHasNotPassed eventId)
-                            >=> check (eventHasOpenedForRegistration eventId)
+                            (check (oneCanParticipateOnEvent eventId)
                             >=> (handle << registerForEvent) (eventId, email))
                             |> withRetry) ] ]

--- a/src/Participants/Queries.fs
+++ b/src/Participants/Queries.fs
@@ -14,7 +14,7 @@ open System.Data.SqlClient
 module Queries =
     let participantsTable = "Participants"
 
-    let handleAggregateToSqlException (exn:Exception) userMessage = 
+    let handleAggregateToSqlException (exn:AggregateException) userMessage = 
           let innerException = exn.InnerException
           match innerException with 
             | :? SqlException as sqlEx ->

--- a/src/Participants/Queries.fs
+++ b/src/Participants/Queries.fs
@@ -1,5 +1,6 @@
 namespace ArrangementService.Participant
 
+open System
 open Microsoft.AspNetCore.Http
 open Dapper.FSharp
 
@@ -13,6 +14,17 @@ open System.Data.SqlClient
 module Queries =
     let participantsTable = "Participants"
 
+    let handleAggregateToSqlException (exn:Exception) userMessage = 
+          let innerException = exn.InnerException
+          match innerException with 
+            | :? SqlException as sqlEx ->
+                match sqlEx.Number with
+                  | 2601 | 2627 ->          // handle constraint error
+                      Error [userMessage]
+                  | _ ->                    // don't handle any other cases, Deadlock will still be raised so it can be catched by withRetry
+                      raise sqlEx
+            | ex -> raise ex
+
     let createParticipant (participant: Participant) (ctx:HttpContext):Result<unit, UserMessage list> =
       try
         insert { table participantsTable
@@ -20,12 +32,9 @@ module Queries =
                 }
                 |> Database.runInsertQuery ctx
       with  
-      | :?SqlException as ex ->    
-        match ex.Number with
-        | 2601 | 2627 ->          // handle constraint error
-            Error [UserMessages.participantDuplicate participant.Email]
-        | _ ->                    // don't handle any other cases, Deadlock will still be raised so it can be catched by withRetry
-            reraise()
+      | :? AggregateException as ex  -> 
+        handleAggregateToSqlException ex (UserMessages.participantDuplicate participant.Email.Unwrap)
+      | ex -> reraise()
 
     let deleteParticipant (participant: Participant) (ctx: HttpContext): Result<unit, UserMessage list> =
         delete { table participantsTable

--- a/src/Participants/UserMessages.fs
+++ b/src/Participants/UserMessages.fs
@@ -13,4 +13,4 @@ module UserMessages =
     let getParticipantsCountFailed (eventId): UserMessage =
         $"Henting av antall deltakere for {eventId} feilet" |> InternalErrorMessage
     let participantDuplicate (email): UserMessage =
-        $"Du er allerede påmeldt med eposten ${email}" |> BadInput
+        $"Du er allerede påmeldt med eposten {email}" |> BadInput


### PR DESCRIPTION
Edit: Innfører breaking changes, frontend må sende med isCancelled i POST og PUT body

I etterkant ser jeg at jeg burde parprogget denne oppgaven, siden jeg har noen spørsmål. PR-er er litt for asynkront, men sånn blir det gjerne med hjemmekontorhybrid

1.Spørsmål: Jeg har valgt å beholde deleteEvent funksjonaliteten, fordi jeg var litt redd for å fjerne. Men jeg foreslår egentlig bare å økse den. Funksjonaliteten mellom delete og cancel er veldig lik og det synes jeg er ganske reflektert i koden ATM. Hva tenker folk? Edit: se commit 979979f7237243630f1f397b304ffc3e9f49a754

2. Se kommentaren min https://github.com/bekk/bekk-arrangement-svc/pull/37/commits/1d5a19478171764c7e8ab654689297310eceb215#r662981119. Det er relatert til det dependencymaset jeg har vært borti

3. Se kommentaren min https://github.com/bekk/bekk-arrangement-svc/pull/37/commits/057611cca32cf2ee9b898e04663efd3624d935d2#r663030209 Her fanger jeg faktisk Integrity error og med committen fikser den buggen som hang igjen. 

4. Ikke et spørsmål men sjekk ut 321d71c866a322249460e5a8624c69f17ca8c4f3 . Der sparer jeg 2 databasekall, som er nice

