### PR TITLE
Check if user is organizer when checking if userCanEditEvent

### DIFF
--- a/src/Events/Authorization.fs
+++ b/src/Events/Authorization.fs
@@ -12,57 +12,72 @@ open System
 
 module Authorization =
 
-    let userCreatedEvent eventId =
+    let userIsOrganizer eventId =
         result {
-            let! editToken = queryParam "editToken"
-
             let! event = Service.getEvent (Id eventId)
 
-            let hasCorrectEditToken =
-                editToken = event.EditToken.ToString()
+            let! userId = getUserId >> Ok
+
+
+            let isTheOrganizer = userId = Some event.OrganizerId.Unwrap
+
+            if isTheOrganizer then
+                return ()
+            else
+                return!
+                    [ AccessDenied $"You are trying to edit an event (id {eventId}) which you did not create" ]
+                    |> Error
+        }
+
+    let userHasCorrectEditToken eventId =
+        result {
+            let! event = Service.getEvent (Id eventId)
+            let! editToken = queryParam "editToken"
+
+            let hasCorrectEditToken = editToken = event.EditToken.ToString()
 
             if hasCorrectEditToken then
                 return ()
             else
-                return! [ AccessDenied $"You are trying to edit an event (id {eventId}) which you did not create"] |> Error
+                return!
+                    [ AccessDenied $"You are trying to edit an event (id {eventId}) using the wrong editToken" ]
+                    |> Error
         }
-    
+
 
     let userCanEditEvent eventId =
-        anyOf
-            [ userCreatedEvent eventId
-              isAdmin ]
+        anyOf [ isAdmin
+                userHasCorrectEditToken eventId
+                userIsOrganizer eventId ]
 
     let userCanSeeParticipants = userCanEditEvent
 
-    let eventHasOpenedForRegistration (event:DomainModels.Event) =
+    let eventHasOpenedForRegistration (event: DomainModels.Event) =
         let openDateTime =
-            DateTimeOffset.FromUnixTimeMilliseconds
-                event.OpenForRegistrationTime.Unwrap
+            DateTimeOffset.FromUnixTimeMilliseconds event.OpenForRegistrationTime.Unwrap
 
         if openDateTime <= DateTimeOffset.Now then
-            Ok ()
+            Ok()
         else
-            Error [ AccessDenied $"Arrangementet åpner for påmelding {openDateTime.ToLocalTime}" ] 
+            Error [ AccessDenied $"Arrangementet åpner for påmelding {openDateTime.ToLocalTime}" ]
 
-    let eventHasNotPassed (event:DomainModels.Event) =
-            if event.EndDate > now() then
-                Ok ()
-            else
-                Error [ AccessDenied "Arrangementet har allerede funnet sted" ] 
+    let eventHasNotPassed (event: DomainModels.Event) =
+        if event.EndDate > now () then
+            Ok()
+        else
+            Error [ AccessDenied "Arrangementet har allerede funnet sted" ]
 
 
-    let eventIsExternal (eventId: Key) = 
+    let eventIsExternal (eventId: Key) =
         result {
             let! event = Service.getEvent (Event.Id eventId)
+
             if event.IsExternal then
                 return ()
             else
-                return! Error [AccessDenied "Event is internal"]
+                return! Error [ AccessDenied "Event is internal" ]
         }
 
-    let eventIsExternalOrUserIsAuthenticated (eventId: Key) = 
-        anyOf
-            [ eventIsExternal eventId
-              isAuthenticated
-            ]
+    let eventIsExternalOrUserIsAuthenticated (eventId: Key) =
+        anyOf [ eventIsExternal eventId
+                isAuthenticated ]


### PR DESCRIPTION
Dette PRen fikser et problem hvor man ikke kunne avlyse sitt eget arrangement, hvis man ikke var admin.

Problemet var at editToken blir ikke sendt med når du avlyser. Jeg tenkte så at man kanskje burde sende med den, men jeg ser at den blir allerede sendt med hvis edittoken er en queryParameter i URLen. Det er den når man deler den unike lenken. Ellers er man jo logget inn og da er det implisitt i brukerId om de har rettigheter nok til å  endre på arrangementet. 

Jeg tror derfor dette er den eneste nødvendinge endringe