### PR TITLE
Assortment preview

### DIFF
--- a/Arrangement-Svc/Program.fs
+++ b/Arrangement-Svc/Program.fs
@@ -42,9 +42,9 @@ let configureApp (app: IApplicationBuilder) =
     |> ignore
     app.UseDefaultFiles() |> ignore
     app.UseStaticFiles() |> ignore
+    app.UseAuthentication() |> ignore
     app.UseMiddleware<Middleware.RequestLogging>() |> ignore
     app.UseRouting() |> ignore
-    app.UseAuthentication() |> ignore
     app.UseCors(configureCors) |> ignore
     app.UseOutputCaching()
     app.UseMiddleware<Middleware.RetryOnDeadlock>() |> ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-# NOTE: When using Alpine, createEvent requests mysteriously dies at decoding
-# the body. This does not happen locally or using Debian. Before changing back
-# to Alpine, make sure the application actually works from Docker
 FROM node:11.14.0 AS node_build
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM node:11.14.0 AS node_base
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
-COPY --from=node_base . .
+# NOTE: When using Alpine, createEvent requests mysteriously dies at decoding
+# the body. This does not happen locally or using Debian. Before changing back
+# to Alpine, make sure the application actually works from Docker
+FROM node:11.14.0 AS node_build
 
 WORKDIR /app
 COPY . .
@@ -8,14 +9,20 @@ COPY . .
 WORKDIR /app/Frontend
 RUN npm ci
 RUN npm run build
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS dotnet_build
+
+WORKDIR /app
+COPY . .
+
 WORKDIR /app/Arrangement-Svc
 RUN dotnet publish -c release -o out
 
 # RUN
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app/
-COPY --from=build /app/Arrangement-Svc/out .
-COPY --from=build /app/Arrangement-Svc/wwwroot wwwroot/.
-COPY --from=build /app/Frontend/build/. wwwroot/.
+COPY --from=dotnet_build /app/Arrangement-Svc/out .
+COPY --from=dotnet_build /app/Arrangement-Svc/wwwroot wwwroot/.
+COPY --from=node_build /app/Frontend/build/. wwwroot/.
 ENV ASPNETCORE_URLS="http://+:80"
 CMD dotnet arrangementSvc.dll

--- a/Frontend/src/auth.ts
+++ b/Frontend/src/auth.ts
@@ -122,7 +122,7 @@ export function isAuthenticated(): boolean {
   return false;
 }
 
-export const needsToAuthenticate = (status: number) => status === 401;
+export const needsToAuthenticate = (status: number) => status === 403;
 
 export function getEmployeeId(): any {
   if (!isAuthenticated()) {


### PR DESCRIPTION
Denne endringen gjør 3 ting:
1. Flytter `useAuthentication` over logging middleware. Da får vi logget ut hvilken bruker som gjør requests
2. Rydder opp i dockerfilen. Bytter om til 2 bygg steg, bruker ikke SDK for å kjøre dotnet
4. Man blir automatisk rutet til innlogging dersom eventet er internt.