### PR TITLE
Create giraffe helpers to log template path

### DIFF
--- a/Arrangement-Svc/Arrangement-Svc.fsproj
+++ b/Arrangement-Svc/Arrangement-Svc.fsproj
@@ -47,6 +47,7 @@
     <Compile Include="Common\Auth.fs" /> 
     <Compile Include="Common\UserMessage.fs" />
     <Compile Include="Common\DatabaseContext.fs" />
+    <Compile Include="Common\GiraffeHelpers.fs" />
     <Compile Include="Models\Models.fs" />
     <Compile Include="Models\SendgridApiModels.fs" />
     <Compile Include="Models\EmailModels.fs" />

--- a/Arrangement-Svc/Common/GiraffeHelpers.fs
+++ b/Arrangement-Svc/Common/GiraffeHelpers.fs
@@ -1,0 +1,25 @@
+module GiraffeHelpers
+
+open Giraffe
+open Microsoft.AspNetCore.Http
+
+// These functions are copies of Giraffes implementation
+// The difference here is that we get the logger from the context and log the template path
+let route (path : string) : HttpHandler =
+    fun (next : HttpFunc) (ctx : HttpContext) ->
+        let logger = ctx.GetService<Bekk.Canonical.Logger.Logger>()
+        logger.log("template_path", path)
+        if (SubRouting.getNextPartOfPath ctx).Equals path
+        then next ctx
+        else skipPipeline
+
+let routef (path : PrintfFormat<_,_,_,_, 'T>) (routeHandler : 'T -> HttpHandler) : HttpHandler =
+    FormatExpressions.validateFormat path
+    fun (next : HttpFunc) (ctx : HttpContext) ->
+        FormatExpressions.tryMatchInput path FormatExpressions.MatchOptions.Exact (SubRouting.getNextPartOfPath ctx)
+        |> function
+            | None      -> skipPipeline
+            | Some args ->
+                let logger = ctx.GetService<Bekk.Canonical.Logger.Logger>()
+                logger.log("template_path", path.Value)
+                routeHandler args next ctx

--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -736,6 +736,7 @@ let deleteParticipantFromEvent (eventId: Guid) (email: string) =
             }
         jsonResult result next context
 
+open GiraffeHelpers
 
 let routes: HttpHandler =
     choose


### PR DESCRIPTION
Legger til 2 funksjoner som er kopiert ut fra Giraffe, men som logger `template-path`.
Dette vil gjøre loggene mye enklere å deale med og kan brukes sammen med dashboardet.

Dette var den beste måten jeg fant å gjøre dette på.

En log linje vil se slik ut:
```json
{
  "method": "GET",
  "request_path": "/api/events/a65f377c-5307-480c-9b39-c4aed44fa49d/participants/bjorn.ivar.strom@bekk.no/waitinglist-spot",
  "request_sent_from": "arrangement-app",
  "template_path": "/api/events/%O/participants/%s/waitinglist-spot",
  "duration": 14,
  "statusCode": "200",
  "timestamp": "2022-08-16T11:44:21",
  "request_id": "451052",
  "log_level": "Information"
}
```