### PR TITLE
Add more info to email sendt to organizer when participant deregisters from event - preview

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -794,7 +794,7 @@ let deleteParticipantFromEvent (eventId: Guid) (email: string) =
                 let participationsAndWaitlist =
                     participants
                     |> Seq.toList
-                    |> participationsToAttendeesAndWaitlist eventAndQuestions.Event.MaxParticipants 
+                    |> participationsToAttendeesAndWaitlist eventAndQuestions.Event.MaxParticipants
                 let participantIsAttendee =
                     participationsAndWaitlist.Attendees
                     |> Seq.exists (fun x -> x.Participant.Email = email)
@@ -807,7 +807,11 @@ let deleteParticipantFromEvent (eventId: Guid) (email: string) =
                     Queries.deleteParticipantFromEvent eventId email db
                     |> TaskResult.mapError InternalError
                 db.Commit()
-                sendParticipantCancelMails eventAndQuestions.Event deletedParticipant personWhoGotIt context
+                let deletedParticipantAnswers =
+                    participants
+                    |> Seq.find (fun pa -> pa.Participant.Email = email)
+                    |> fun p -> p.Answers
+                sendParticipantCancelMails eventAndQuestions.Event eventAndQuestions.Questions deletedParticipant deletedParticipantAnswers personWhoGotIt context
                 return ()
             }
         jsonResult result next context

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -183,17 +183,21 @@ let private createCancelledParticipationMailToOrganizer
     participantAnswers
     =
         let message =
-            let questionAnswerString =
-                List.map (fun (question: ParticipantQuestion) ->
-                   let answer = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
-                   $"- {question.Question}<br>{answer.Answer}<br><br>"
-                ) eventQuestions
+            let participantInfo =
+                let questionAnswerString =
+                    List.map (fun (question: ParticipantQuestion) ->
+                       let answer = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
+                       $"- {question.Question}<br>{answer.Answer}<br><br>"
+                    ) eventQuestions
+                [
+                    ""
+                    "Deltaker har svart:"
+                    ""
+                    yield! questionAnswerString
+                ]
             [ $"{participant.Name} har meldt seg av {event.Title}"
               if List.isEmpty eventQuestions = false then
-                  ""
-                  "Deltaker har svart:"
-                  ""
-                  yield! questionAnswerString
+                  yield! participantInfo
             ] |> String.concat "<br>"
         { Subject = "Avmelding"
           Message = message

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -189,10 +189,11 @@ let private createCancelledParticipationMailToOrganizer
                    $"- {question.Question}<br>{answer.Answer}<br><br>"
                 ) eventQuestions
             [ $"{participant.Name} har meldt seg av {event.Title}"
-              ""
-              "Deltaker har svart:"
-              ""
-              yield! questionAnswerString
+              if List.isEmpty eventQuestions = false then
+                  ""
+                  "Deltaker har svart:"
+                  ""
+                  yield! questionAnswerString
             ] |> String.concat "<br>"
         { Subject = "Avmelding"
           Message = message

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -194,16 +194,6 @@ let private createCancelledParticipationMailToOrganizer
               ""
               yield! questionAnswerString
             ] |> String.concat "<br>"
-//        let stringBuilder = StringBuilder()
-//        stringBuilder.AppendLine
-//        if List.isEmpty eventQuestions = false then
-//            stringBuilder.AppendLine "Deltaker har svart:<br>" |> ignore
-//            List.iter (fun question ->
-//                stringBuilder.AppendLine $"- {question.Question}<br>" |> ignore
-//                let question = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
-//                stringBuilder.AppendLine $"{question.Answer}<br>" |> ignore
-//                stringBuilder.AppendLine "<br><br>" |> ignore
-//            ) eventQuestions
         { Subject = "Avmelding"
           Message = message
           To = event.OrganizerEmail

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -182,18 +182,30 @@ let private createCancelledParticipationMailToOrganizer
     participant
     participantAnswers
     =
-        let stringBuilder = StringBuilder()
-        stringBuilder.AppendLine $"{participant.Name} har meldt seg av {event.Title}<br><br>" |> ignore
-        if List.isEmpty eventQuestions = false then
-            stringBuilder.AppendLine "Deltaker har svart:<br>" |> ignore
-            List.iter (fun question ->
-                stringBuilder.AppendLine $"- {question.Question}<br>" |> ignore
-                let question = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
-                stringBuilder.AppendLine $"{question.Answer}<br>" |> ignore
-                stringBuilder.AppendLine "<br><br>" |> ignore
-            ) eventQuestions
+        let message =
+            let questionAnswerString =
+                List.map (fun (question: ParticipantQuestion) ->
+                   let answer = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
+                   $"- {question.Question}<br>{answer.Answer}"
+                ) eventQuestions
+            [ $"{participant.Name} har meldt seg av {event.Title}"
+              ""
+              "Deltaker har svart:"
+              ""
+              yield! questionAnswerString
+            ] |> String.concat "<br>"
+//        let stringBuilder = StringBuilder()
+//        stringBuilder.AppendLine
+//        if List.isEmpty eventQuestions = false then
+//            stringBuilder.AppendLine "Deltaker har svart:<br>" |> ignore
+//            List.iter (fun question ->
+//                stringBuilder.AppendLine $"- {question.Question}<br>" |> ignore
+//                let question = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
+//                stringBuilder.AppendLine $"{question.Answer}<br>" |> ignore
+//                stringBuilder.AppendLine "<br><br>" |> ignore
+//            ) eventQuestions
         { Subject = "Avmelding"
-          Message = stringBuilder.ToString()
+          Message = message
           To = event.OrganizerEmail
           CalendarInvite = None
         }

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -186,7 +186,7 @@ let private createCancelledParticipationMailToOrganizer
             let questionAnswerString =
                 List.map (fun (question: ParticipantQuestion) ->
                    let answer = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
-                   $"- {question.Question}<br>{answer.Answer}"
+                   $"- {question.Question}<br>{answer.Answer}<br><br>"
                 ) eventQuestions
             [ $"{participant.Name} har meldt seg av {event.Title}"
               ""

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -101,8 +101,8 @@ let organizerAsParticipant (event: Models.Event): Participant =
       Name = event.OrganizerName
       Email = event.OrganizerEmail
       EventId = event.Id
-      RegistrationTime = System.DateTimeOffset.Now.ToUnixTimeSeconds()
-      CancellationToken = System.Guid.Empty
+      RegistrationTime = DateTimeOffset.Now.ToUnixTimeSeconds()
+      CancellationToken = Guid.Empty
       EmployeeId = Some event.OrganizerId
     }
 
@@ -178,13 +178,25 @@ let createNewParticipantMail
 
 let private createCancelledParticipationMailToOrganizer
     (event: Models.Event)
-    (participant: Models.Participant)
+    eventQuestions
+    participant
+    participantAnswers
     =
-    { Subject = "Avmelding"
-      Message = $"{participant.Name} har meldt seg av {event.Title}"
-      To = event.OrganizerEmail
-      CalendarInvite = None
-    }
+        let stringBuilder = StringBuilder()
+        stringBuilder.AppendLine $"{participant.Name} har meldt seg av {event.Title}" |> ignore
+        if List.isEmpty eventQuestions = false then
+            stringBuilder.AppendLine "Deltaker har svart:" |> ignore
+            List.iter (fun question ->
+                stringBuilder.AppendLine $"- {question.Question}" |> ignore
+                let question = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
+                stringBuilder.AppendLine question.Answer |> ignore
+                stringBuilder.AppendLine "</br>" |> ignore
+            ) eventQuestions
+        { Subject = "Avmelding"
+          Message = stringBuilder.ToString()
+          To = event.OrganizerEmail
+          CalendarInvite = None
+        }
 
 let private createCancelledParticipationMailToAttendee
     (event: Models.Event)
@@ -232,16 +244,16 @@ let private sendMailToFirstPersonOnWaitingList
     =
     sendMail (createFreeSpotAvailableMail event personWhoGotIt) context
 
-let private sendMailToOrganizerAboutCancellation (event: Models.Event) participant context =
-    let mail = createCancelledParticipationMailToOrganizer event participant
+let private sendMailToOrganizerAboutCancellation event eventQuestions participant participantAnswers context =
+    let mail = createCancelledParticipationMailToOrganizer event eventQuestions participant participantAnswers
     sendMail mail context
 
 let private sendMailWithCancellationConfirmation event participant context =
     let mail = createCancelledParticipationMailToAttendee event participant
     sendMail mail context
 
-let sendParticipantCancelMails (event: Models.Event) (participant: Models.Participant) (personWhoGotIt: ParticipantAndAnswers option) context =
-    sendMailToOrganizerAboutCancellation event participant context
+let sendParticipantCancelMails (event: Models.Event) (eventQuestions: ParticipantQuestion list) (participant: Models.Participant) (participantAnswers: ParticipantAnswer list) (personWhoGotIt: ParticipantAndAnswers option) context =
+    sendMailToOrganizerAboutCancellation event eventQuestions participant participantAnswers context
     sendMailWithCancellationConfirmation event participant context
     match personWhoGotIt with
     | Some person -> sendMailToFirstPersonOnWaitingList event person.Participant context

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -183,13 +183,13 @@ let private createCancelledParticipationMailToOrganizer
     participantAnswers
     =
         let stringBuilder = StringBuilder()
-        stringBuilder.AppendLine $"{participant.Name} har meldt seg av {event.Title}" |> ignore
+        stringBuilder.AppendLine $"{participant.Name} har meldt seg av {event.Title}<br>" |> ignore
         if List.isEmpty eventQuestions = false then
-            stringBuilder.AppendLine "Deltaker har svart:" |> ignore
+            stringBuilder.AppendLine "Deltaker har svart:<br>" |> ignore
             List.iter (fun question ->
-                stringBuilder.AppendLine $"- {question.Question}" |> ignore
+                stringBuilder.AppendLine $"- {question.Question}<br>" |> ignore
                 let question = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
-                stringBuilder.AppendLine question.Answer |> ignore
+                stringBuilder.AppendLine $"{question.Answer}<br>" |> ignore
                 stringBuilder.AppendLine "</br>" |> ignore
             ) eventQuestions
         { Subject = "Avmelding"

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -183,14 +183,14 @@ let private createCancelledParticipationMailToOrganizer
     participantAnswers
     =
         let stringBuilder = StringBuilder()
-        stringBuilder.AppendLine $"{participant.Name} har meldt seg av {event.Title}<br>" |> ignore
+        stringBuilder.AppendLine $"{participant.Name} har meldt seg av {event.Title}<br><br>" |> ignore
         if List.isEmpty eventQuestions = false then
             stringBuilder.AppendLine "Deltaker har svart:<br>" |> ignore
             List.iter (fun question ->
                 stringBuilder.AppendLine $"- {question.Question}<br>" |> ignore
                 let question = List.find (fun (a: ParticipantAnswer) -> a.QuestionId = question.Id) participantAnswers
                 stringBuilder.AppendLine $"{question.Answer}<br>" |> ignore
-                stringBuilder.AppendLine "</br>" |> ignore
+                stringBuilder.AppendLine "<br><br>" |> ignore
             ) eventQuestions
         { Subject = "Avmelding"
           Message = stringBuilder.ToString()


### PR DESCRIPTION
Arrangør får mer informasjon når noen melder seg av.

Det ser slik ut: 
![image](https://user-images.githubusercontent.com/8441485/191017621-f71ccda8-1f2e-4b60-bd02-f034cb8337c2.png)

Knyttet til: https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwPsujnaW0K3KKpU/recgaH1Px9DN8OQ8U?blocks=hide
