### PR TITLE
Clear state after creating and updating events - preview

### DIFF
--- a/Frontend/src/components/PreviewEvent/PreviewEventContainer.tsx
+++ b/Frontend/src/components/PreviewEvent/PreviewEventContainer.tsx
@@ -20,6 +20,7 @@ import {
 } from 'src/types/event';
 import {useSetTitle} from "src/hooks/setTitle";
 import {appTitle} from "src/Constants";
+import {clearSessionState} from "../../hooks/sessionState";
 
 export const PreviewEventContainer = () => {
   const { catchAndNotify } = useNotification();
@@ -45,6 +46,7 @@ export const PreviewEventContainer = () => {
 
   const putEditedEvent = catchAndNotify(async () => {
     await putEvent(eventId, event, editToken);
+    clearSessionState(eventId);
     history.push(
       event.shortname
         ? viewEventShortnameRoute(event.shortname)

--- a/Frontend/src/components/PreviewEvent/PreviewNewEventContainer.tsx
+++ b/Frontend/src/components/PreviewEvent/PreviewNewEventContainer.tsx
@@ -18,6 +18,7 @@ import {
   maxParticipantsLimit,
 } from 'src/types/event';
 import {useSetTitle} from "src/hooks/setTitle";
+import {clearSessionState} from "../../hooks/sessionState";
 
 export const PreviewNewEventContainer = () => {
   const { catchAndNotify } = useNotification();
@@ -49,6 +50,7 @@ export const PreviewNewEventContainer = () => {
       editToken,
     } = await postEvent(event, editUrlTemplate);
     saveEditableEvent({ eventId: id, editToken });
+    clearSessionState("createEvent")
     history.push(
       shortname ? viewEventShortnameRoute(shortname) : viewEventRoute(id)
     );

--- a/Frontend/src/hooks/sessionState.ts
+++ b/Frontend/src/hooks/sessionState.ts
@@ -23,3 +23,5 @@ export function useSessionState<T>(initialState: T, key: string) {
     })
   ]
 }
+
+export const clearSessionState = (key: string) => window.sessionStorage.removeItem(key);


### PR DESCRIPTION
Fikser buggen som gjør at state henger igjen etter man har laget/editert et event.

Buggen som blir fiksa reproduseres slik:
- Lag et arrangement
- Etter det er oppretta, gå rett inn å lag et nytt arrangement
- Da skal alle verdiene du skrev inn for det første arrangementet fortsatt være der.