### PR TITLE
Check actual participation status before sending email after participant registration - preview

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -176,8 +176,12 @@ let registerParticipationHandler (eventId: Guid, email): HttpHandler =
                 let! participant = participant |> Result.mapError InternalError
                 let! answers = answers |> Result.mapError InternalError
                 db.Commit()
+                use db = openConnection context
+                let! isParticipating =
+                    Queries.isParticipating eventId email db
+                    |> TaskResult.mapError InternalError
                 // Sende epost
-                let isWaitlisted = participate = IsWaitListed
+                let isWaitlisted = isParticipating = false
                 let email =
                     let redirectUrlTemplate =
                         HttpUtility.UrlDecode writeModel.CancelUrlTemplate

--- a/migration/Migrations/34-ParticipantsEventIdIndex.sql
+++ b/migration/Migrations/34-ParticipantsEventIdIndex.sql
@@ -1,0 +1,4 @@
+USE [arrangement-db];
+
+create index Participants_EventId_index
+    on dbo.Participants (EventId)


### PR DESCRIPTION
Race condition når man registrerer seg til et arrangement.

Om 2 personer prøver å registrere seg samtidig får begge beskjed om at det er plass og begge får epost som sier det - selv om det bare er 1 av de som faktisk har plass.

Denne endringen gjør følgende:
1 - Legger til en query som kan brukes til å sjekke om en participant er på ventelisten på et arrangement.
2 - Denne querien brukes til å sjekke hva status på personen faktisk er før epost sendes
3 - Legger til en index på `Participant` tabellen så dette skal gå så raskt som mulig