### PR TITLE
Diverse fikser for at testene skal kjøre bedre lokalt

### DIFF
--- a/Arrangement-Svc/Queries/Queries.fs
+++ b/Arrangement-Svc/Queries/Queries.fs
@@ -92,7 +92,7 @@ let getEventsForForside (email: string) (db: DatabaseContext) =
 
         let parameters = dict [
             "email", box email
-            "now", box (DateTime.Now.Date.ToString())
+            "now", box (DateTime.Now.Date.ToString("o"))
         ]
 
         try
@@ -675,7 +675,7 @@ let updateEvent eventId (model: Models.EventWriteModel) (db: DatabaseContext) =
 
         let parameters = dict [
             "eventId", box (eventId.ToString())
-            "now", box (DateTime.Now.Date.ToString())
+            "now", box (DateTime.Now.Date.ToString("o"))
 
             "title", box model.Title
             "description", box model.Description
@@ -738,7 +738,7 @@ let doesShortnameExist (shortname: string option) (db: DatabaseContext) =
 
         let parameters = dict [
             "shortname", box (if shortname.IsSome then shortname.Value else null)
-            "now", box (DateTime.Now.Date.ToString())
+            "now", box (DateTime.Now.Date.ToString("o"))
         ]
 
         try
@@ -887,7 +887,7 @@ let createEvent (writeModel: Models.EventWriteModel) employeeId (db: DatabaseCon
             "customHexColor", (if writeModel.CustomHexColor.IsSome then writeModel.CustomHexColor.Value else box null)
             "shortname", (if writeModel.Shortname.IsSome then writeModel.Shortname.Value else box null)
             "program", (if writeModel.Program.IsSome then writeModel.Program.Value else box null)
-            "now", box (DateTime.Now.Date.ToString())
+            "now", box (DateTime.Now.Date.ToString("o"))
         ]
 
         try

--- a/Tests/Utils/Container.fs
+++ b/Tests/Utils/Container.fs
@@ -41,7 +41,7 @@ let containerExists () =
 
 let containerIsStopped () =
     let result =
-        runCLI $"""ps --all --filter name={ContainerName} --format "{{{{.Status}}}}" """
+        runCLI $"""ps --all --filter name={ContainerName} --format "{{.Status}}" """
 
     match result.Text with
     | None -> failwith "Error when getting container info"

--- a/Tests/Utils/Http.fs
+++ b/Tests/Utils/Http.fs
@@ -18,14 +18,14 @@ let decode<'a> (content: string) = content |> Decode.Auto.fromString<'a>
 let request (client: HttpClient) (url: string) (body: 'a option) (method: HttpMethod) =
     let url =
         if url.StartsWith("/") then
-            $"/api{url}"
+            Uri($"/api{url}", UriKind.Relative)
         else
-            $"{url}"
+            Uri(url)
 
     task {
         let request = new HttpRequestMessage()
         request.Method <- method
-        request.RequestUri <- Uri(url)
+        request.RequestUri <- url
 
         body
         |> Option.iter (fun body ->


### PR DESCRIPTION
Denne PRen inneholder 3 endringer for at testene skal kjøre lokalt på min Windows-maskin.
Forhåpentligvis er det endringer som ikke påvirker noen andre.


# Endring 1

På min maskin har jeg engelsk Windows, men norsk datoformatering.
Det fungerer ikke bra med `DateTime` sin `ToString()`.
For at datoen skal bli lik så kan man spesifisere round trip formatet med `ToString("o")`.
Da blir datoformatet noe sånt: `2009-06-15T13:45:30.0000000Z`

https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip


Testene lokalt uten formatering:

```
Failed!  - Failed:    61, Passed:    49, Skipped:     0, Total:   110, Duration: 5 s - Tests.dll (net6.0)
```


Testene lokalt med formatering:

```
Passed!  - Failed:     0, Passed:   110, Skipped:     0, Total:   110, Duration: 8 s - Tests.dll (net6.0)
```

# Endring 2

Når jeg kjører testene lokalt så kastes exceptions for når det lages en `URI` som kun inneholder path, f.eks. `/api/events`.
Løsningen ble å spesifisere `UriKind.Relative`.
Jeg har ingen aning hvorfor dette skjer for meg, og ikke når testene kjøres via GH actions.

Kanskje det har noe med F#-versjon å gjøre. Jeg har dotnet 7 installert og siste versjon av F#, men når prosjektet spesifiserer dotnet 6 så hadde jeg jo forventet at den velger riktig av F#.

Det lukter jo litt at `System.Uri` fungerer annerledes på Windows og Mac akkurat i dette tilfellet.

# Endring 3

Den format templaten som er brukt under fungerer ikke på min maskin.
For de andre CLI-kallene så er det brukt kun 2 curly brackets på hver side, og de fungerer fint.

Hvis jeg endrer til `{{.Status}}` så fungerer det både for podman og for docker, og `containerIsStopped` fungerer fortsatt.

Koden det gjelder:

```
let containerIsStopped () =
    let result =
        runCLI $"""ps --all --filter name={ContainerName} --format "{{{{.Status}}}}" """

    match result.Text with
    | None -> failwith "Error when getting container info"
    | Some text -> text.Contains "Exited"
```

Docker:

```
$ docker ps --format "{{{{.Status}}}}"
failed to parse template: template: :1: unexpected "{" in command
$ docker ps -a --format "{{.Status}}"
Exited (0) 11 seconds ago
$ docker --version
Docker version 20.10.21, build baeda1f
```

Podman:

```
$ podman ps --format "{{{{.Status}}}}" 
Error: template: ps:1: unexpected "{" in command
$ podman ps -a --format "{{.Status}}"
Exited (0) 4 hours ago
$ podman --version
podman.exe version 4.3.1
```

