### PR TITLE
Add timezone marker to date-string if it is UTC - preview

### DIFF
--- a/Arrangement-Svc/OfficeEvents.fs
+++ b/Arrangement-Svc/OfficeEvents.fs
@@ -176,6 +176,12 @@ module CalendarLookup =
 module WebApi =
     open Microsoft.AspNetCore.Http
     open Giraffe
+    
+    // Used to add timezone marker to the date-string as microsoft chose not to follow the standard here.
+    // If its not in UTC then something is terribly wrong, so then we just return the string as we get it
+    let generateTimezoneString dateString timeZone =
+        let timezone = if timeZone = "UTC" then "z" else ""
+        $"{dateString}{timezone}"
 
     let get (date: string) (next: HttpFunc) (context: HttpContext) =
         let result =
@@ -204,8 +210,8 @@ module WebApi =
                            Description = body.description
                            Types = body.types
                            Themes = body.themes
-                           StartTime = e.Start.DateTime
-                           EndTime = e.End.DateTime
+                           StartTime = generateTimezoneString e.Start.DateTime e.Start.TimeZone
+                           EndTime = generateTimezoneString e.End.DateTime e.End.TimeZone
                            ContactPerson = e.Organizer.EmailAddress.Name;
                            ModifiedAt = e.LastModifiedDateTime.Value.UtcDateTime;
                            CreatedAt = e.CreatedDateTime.Value.UtcDateTime;


### PR DESCRIPTION
Fikser tid problemer office-events:
Viser seg at microsoft stripper timezone markør fra dato-strengen - selvom den er UTC.

Løsningen er å sjekke om timezone som er et field i objektet er "UTC" og isåfall legge til "Z".
Litt usikker på hvordan håndtere dette dersom det er noe annet enn UTC, så da gjøres det ingen endringen - aka det blir likt som det er i prod per nå.