### PR TITLE
Bug/waitlist email when not waitlisted - preview

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -137,8 +137,8 @@ let registerParticipationHandler (eventId: Guid, email): HttpHandler =
                     Queries.getNumberOfParticipantsForEvent eventId db
                     |> TaskResult.mapError InternalError
 
-                // Verdien blir ignorert da vi nå kun bruker dette til å kaste Error casene som feil.
-                // Om arrangemenet har plass eller man er ventelista henter vi ut fra databasen lenger ned
+                // Verdien blir ignorert da vi nå kun bruker dette til å returnere riktig feil til brukeren.
+                // Om arrangemenet har plass eller man er ventelista henter vi ut fra databasen lenger ned.
                 let! _ =
                     match participateEvent isBekker numberOfParticipants eventAndQuestions.Event with
                         | NotExternal ->

--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -137,7 +137,9 @@ let registerParticipationHandler (eventId: Guid, email): HttpHandler =
                     Queries.getNumberOfParticipantsForEvent eventId db
                     |> TaskResult.mapError InternalError
 
-                let! participate =
+                // Verdien blir ignorert da vi nå kun bruker dette til å kaste Error casene som feil.
+                // Om arrangemenet har plass eller man er ventelista henter vi ut fra databasen lenger ned
+                let! _ =
                     match participateEvent isBekker numberOfParticipants eventAndQuestions.Event with
                         | NotExternal ->
                             Error "Arrangementet er ikke eksternt"
@@ -149,10 +151,7 @@ let registerParticipationHandler (eventId: Guid, email): HttpHandler =
                             Error "Arrangementet tok sted i fortiden"
                         | NoRoom ->
                             Error "Arrangementet har ikke plass"
-                        | IsWaitListed ->
-                            Ok IsWaitListed
-                        | CanParticipate ->
-                            Ok CanParticipate
+                        | IsWaitListed | CanParticipate -> Ok ()
                     |> Result.mapError (fun e -> BadRequest e)
 
                 let! participant, answers =
@@ -185,7 +184,7 @@ let registerParticipationHandler (eventId: Guid, email): HttpHandler =
                     Queries.isParticipating eventId email db
                     |> TaskResult.mapError InternalError
                 // Sende epost
-                let isWaitlisted = isParticipating = false
+                let isWaitlisted = eventAndQuestions.Event.HasWaitingList && isParticipating = false
                 let email =
                     let redirectUrlTemplate =
                         HttpUtility.UrlDecode writeModel.CancelUrlTemplate

--- a/Tests/RegisterToEvent.fs
+++ b/Tests/RegisterToEvent.fs
@@ -198,7 +198,7 @@ type RegisterToEvent(fixture: DatabaseFixture) =
         }
         
     [<Fact>]
-    member _.``Emails sent when event is full with mailbox has the correct amount of participating and waitlisted emails``() =
+    member _.``Emails sent when event is full has the correct amount of participating and waitlisted emails``() =
         let generatedEvent =
             TestData.createEvent (fun e ->
                 { e with MaxParticipants = Some 2

--- a/Tests/RegisterToEvent.fs
+++ b/Tests/RegisterToEvent.fs
@@ -5,6 +5,7 @@ open System.Net
 
 open Models
 open Tests
+open Email.Service
 
 [<Collection("Database collection")>]
 type RegisterToEvent(fixture: DatabaseFixture) =
@@ -13,6 +14,9 @@ type RegisterToEvent(fixture: DatabaseFixture) =
 
     let unauthenticatedClient =
         fixture.getUnauthenticatedClient
+        
+    let isParticipatingEmail (email: DevEmail) = email.Email.Message.Contains "Du er nå påmeldt"
+    let isWaitlistedEmail (email: DevEmail) = email.Email.Message.Contains "Du er nå på venteliste"
 
     [<Fact>]
     member _.``Unauthenticated user can join external event``() =
@@ -151,4 +155,93 @@ type RegisterToEvent(fixture: DatabaseFixture) =
 
             authenticatedResponse.EnsureSuccessStatusCode()
             |> ignore
+        }
+        
+    [<Fact>]
+    member _.``Email gets sent when registering``() =
+        let generatedEvent =
+            TestData.createEvent (fun e ->
+                { e with
+                    IsExternal = true
+                    MaxParticipants = None })
+
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient generatedEvent
+            // Clear the mailbox after the event was created
+            emptyDevMailbox ()
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            
+            let mailbox = getDevMailbox ()
+            
+            Assert.Equal(1, List.length mailbox)
+        }
+        
+    [<Fact>]
+    member _.``Emails sent when event is full is waitlist email``() =
+        let generatedEvent =
+            TestData.createEvent (fun e ->
+                { e with MaxParticipants = Some 0 })
+
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient generatedEvent
+            // Clear the mailbox after the event was created
+            emptyDevMailbox ()
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            
+            let mailbox = getDevMailbox ()
+            
+            Assert.True(List.forall isWaitlistedEmail mailbox)
+        }
+        
+    [<Fact>]
+    member _.``Emails sent when event is full with mailbox has the correct amount of participating and waitlisted emails``() =
+        let generatedEvent =
+            TestData.createEvent (fun e ->
+                { e with MaxParticipants = Some 2
+                         HasWaitingList = true })
+
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient generatedEvent
+            // Clear the mailbox after the event was created
+            emptyDevMailbox ()
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            
+            let mailbox = getDevMailbox ()
+            
+            let participating = List.filter isParticipatingEmail mailbox
+            let waitlisted = List.filter isWaitlistedEmail mailbox
+            
+            Assert.Equal(5, List.length mailbox)
+            Assert.Equal(2, List.length participating)
+            Assert.Equal(3, List.length waitlisted)
+        }
+        
+    [<Fact>]
+    member _.``Emails with no max-participants and no waitinglist sends participating email``() =
+        let generatedEvent =
+            TestData.createEvent (fun e ->
+                { e with MaxParticipants = None
+                         HasWaitingList = false })
+
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient generatedEvent
+            // Clear the mailbox after the event was created
+            emptyDevMailbox ()
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            let! _, _ = Helpers.createParticipant authenticatedClient createdEvent.Event.Id
+            
+            let mailbox = getDevMailbox ()
+            
+            Assert.True(List.forall isParticipatingEmail mailbox)
         }


### PR DESCRIPTION
Registrering tar ikke hensyn til om det finnes en venteliste eller ikke når den sender epost.

Denne fiksen legger til tester som sjekker dette samtidig som den legger til at registrering sjekker om det finnes en venteliste.