### PR TITLE
Bug/delete participant - preview

### DIFF
--- a/Arrangement-Svc/Common/UserMessage.fs
+++ b/Arrangement-Svc/Common/UserMessage.fs
@@ -53,6 +53,7 @@ let csvResult filename result (next: HttpFunc) (context: HttpContext) =
 
 module ResponseMessages =
     let eventNotFound id: HttpStatus = $"Kan ikke finne event {id}" |> NotFound
+    let participantNotFound email eventId: HttpStatus = $"Kan finne deltaker med epost {email} på event {eventId}" |> NotFound
     let eventSuccessfullyCancelled title: string = $"Arrangement: '{title}' blei avlyst. Epost har blitt sendt til alle deltagere"
     let invalidMaxParticipantValue : HttpStatus = "Du kan ikke sette maks deltagere til lavere enn antall som allerede deltar" |> BadRequest
     let invalidRemovalOfWaitingList : HttpStatus = "Du kan ikke fjerne venteliste når det er folk på den" |> BadRequest

--- a/Arrangement-Svc/Common/UserMessage.fs
+++ b/Arrangement-Svc/Common/UserMessage.fs
@@ -53,8 +53,8 @@ let csvResult filename result (next: HttpFunc) (context: HttpContext) =
 
 module ResponseMessages =
     let eventNotFound id: HttpStatus = $"Kan ikke finne event {id}" |> NotFound
-    let participantNotFound email eventId: HttpStatus = $"Kan finne deltaker med epost {email} på event {eventId}" |> NotFound
-    let eventSuccessfullyCancelled title: string = $"Arrangement: '{title}' blei avlyst. Epost har blitt sendt til alle deltagere"
+    let participantNotFound email eventId: HttpStatus = $"Kan ikke finne deltaker med epost {email} på event {eventId}" |> NotFound
+    let eventSuccessfullyCancelled title: string = $"Arrangement: '{title}' ble avlyst. Epost har blitt sendt til alle deltagere"
     let invalidMaxParticipantValue : HttpStatus = "Du kan ikke sette maks deltagere til lavere enn antall som allerede deltar" |> BadRequest
     let invalidRemovalOfWaitingList : HttpStatus = "Du kan ikke fjerne venteliste når det er folk på den" |> BadRequest
     let couldNotRetrieveUserId : HttpStatus = "Kunne ikke hente ut bruker-id" |> BadRequest

--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -806,6 +806,9 @@ let deleteParticipantFromEvent (eventId: Guid) (email: string) =
                 let! participant =
                     Queries.getParticipantForEvent eventId email db
                     |> TaskResult.mapError InternalError
+                let! participant =
+                    participant
+                    |> Result.requireSome (participantNotFound email eventId)
                 do! (isAdmin || (cancellationToken.IsSome && cancellationToken.Value = participant.CancellationToken))
                     |> Result.requireTrue cannotDeleteParticipation
                 let! eventAndQuestions =

--- a/Arrangement-Svc/Queries/Queries.fs
+++ b/Arrangement-Svc/Queries/Queries.fs
@@ -953,10 +953,14 @@ let getParticipantForEvent eventId email (db: DatabaseContext) =
         |}
 
         try
-            let! result = db.Connection.QuerySingleAsync<Models.Participant>(query, parameters, db.Transaction)
-            return Ok result
+            let! result = db.Connection.QuerySingleOrDefaultAsync<Models.Participant>(query, parameters, db.Transaction)
+            if isNull (box result) then
+                return Ok None
+            else
+                return Ok (Some result)
         with
-            | ex -> return Error ex
+            | ex ->
+                return Error ex
     }
 
 let getParticipantsAndAnswersForEvent (eventId: Guid) (db: DatabaseContext) =

--- a/Tests/Fixture.fs
+++ b/Tests/Fixture.fs
@@ -30,24 +30,23 @@ type DatabaseFixture() =
             printfn "Container already up and running. Reusing container for tests."
 
     member this.getAuthedClientWithClaims (employeeId: int) (permissions: string list) =
-        let a =
-            this
-                .WithWebHostBuilder(fun builder ->
-                    builder.ConfigureTestServices (fun (services: IServiceCollection) ->
-                        services.Configure<TestAuthHandlerOptions> (fun (options: TestAuthHandlerOptions) ->
-                            options.EmployeeId <- employeeId
-                            options.BekkPermissions <- permissions)
-                        |> ignore
+        this
+            .WithWebHostBuilder(fun builder ->
+                builder.ConfigureTestServices (fun (services: IServiceCollection) ->
+                    services.Configure<TestAuthHandlerOptions> (fun (options: TestAuthHandlerOptions) ->
+                        options.EmployeeId <- employeeId
+                        options.BekkPermissions <- permissions)
+                    |> ignore
 
-                        services
-                            .AddAuthentication(fun options ->
-                                options.DefaultAuthenticateScheme <- "Test"
-                                options.DefaultScheme <- "Test"
-                                ())
-                            .AddScheme<TestAuthHandlerOptions, TestAuthHandler>("Test", (fun options -> ()))
-                        |> ignore)
+                    services
+                        .AddAuthentication(fun options ->
+                            options.DefaultAuthenticateScheme <- "Test"
+                            options.DefaultScheme <- "Test"
+                            ())
+                        .AddScheme<TestAuthHandlerOptions, TestAuthHandler>("Test", (fun options -> ()))
                     |> ignore)
-        a.CreateClient()
+                |> ignore)
+            .CreateClient()
 
     member this.getAuthedClient = this.getAuthedClientWithClaims 0 []
 

--- a/Tests/Fixture.fs
+++ b/Tests/Fixture.fs
@@ -58,8 +58,8 @@ type DatabaseFixture() =
             .CreateClient()
             
     member this.dbContext =
-        let cn = new SqlConnection(connectionString)
-        new DatabaseContext(cn, null)
+        let databaseConnection = new SqlConnection(connectionString)
+        new DatabaseContext(databaseConnection, null)
 
 [<CollectionDefinition("Database collection")>]
 type DatabaseCollection() =

--- a/Tests/GetEvent.fs
+++ b/Tests/GetEvent.fs
@@ -399,3 +399,4 @@ type GetEvent(fixture: DatabaseFixture) =
 
             response.EnsureSuccessStatusCode() |> ignore
         }
+        

--- a/Tests/Query.fs
+++ b/Tests/Query.fs
@@ -119,7 +119,7 @@ type Queries(fixture: DatabaseFixture) =
         
     [<Fact>]
     member _.``Getting events from forside. Has correct user specific info when is not waitlisted``() =
-        let event = TestData.createEvent (fun e -> { e with IsExternal = false; MaxParticipants = None })
+        let event = TestData.createEvent (fun e -> { e with IsExternal = false; HasWaitingList = false; MaxParticipants = None })
         task {
             let! createdEvent = Helpers.createEventAndGet authenticatedClient event
             let! createdParticipant = Helpers.createParticipantAndGet authenticatedClient createdEvent.Event.Id
@@ -134,7 +134,7 @@ type Queries(fixture: DatabaseFixture) =
                 match returnedEvent with
                 | None -> failwith "Test failed: Could not find event"
                 | Some event ->
-                    Assert.True(event.HasWaitingList)
+                    Assert.False(event.HasWaitingList)
                     Assert.True(event.IsParticipating)
                     Assert.True(event.HasRoom)
                     Assert.False(event.IsWaitlisted)

--- a/Tests/Query.fs
+++ b/Tests/Query.fs
@@ -8,6 +8,36 @@ type Queries(fixture: DatabaseFixture) =
     let authenticatedClient =
         fixture.getAuthedClient
         
+        
+    [<Fact>]
+    member _.``Check if event is external returns true if event is external``() =
+        let event =
+            TestData.createEvent (fun e -> { e with IsExternal = true })
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient event
+            let eventId = System.Guid.Parse createdEvent.Event.Id
+            let! result = Queries.isEventExternal eventId fixture.dbContext
+
+            match result with
+            | Ok isExternal -> Assert.True(isExternal)
+            | Error e -> failwith $"Test failed: {e}"
+        }
+
+    [<Fact>]
+    member _.``Check if event is external returns false if event is not external``() =
+        let event =
+            TestData.createEvent (fun e -> { e with IsExternal = false })
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient event
+            let eventId = System.Guid.Parse createdEvent.Event.Id
+            let! result = Queries.isEventExternal eventId fixture.dbContext
+
+            match result with
+            | Ok isExternal -> Assert.False(isExternal)
+            | Error e -> failwith $"Test failed: {e}"
+        }
+
+        
     [<Fact>]
     member _.``Querying non-existing participant gives no result``() =
         task {

--- a/Tests/Query.fs
+++ b/Tests/Query.fs
@@ -3,7 +3,6 @@ namespace Tests.General
 open Models
 open Tests
 open Xunit
-open Xunit.Abstractions
 
 [<Collection("Database collection")>]
 type Queries(fixture: DatabaseFixture) =

--- a/Tests/Query.fs
+++ b/Tests/Query.fs
@@ -8,7 +8,6 @@ type Queries(fixture: DatabaseFixture) =
     let authenticatedClient =
         fixture.getAuthedClient
         
-        
     [<Fact>]
     member _.``Check if event is external returns true if event is external``() =
         let event =
@@ -36,8 +35,61 @@ type Queries(fixture: DatabaseFixture) =
             | Ok isExternal -> Assert.False(isExternal)
             | Error e -> failwith $"Test failed: {e}"
         }
-
         
+    [<Fact>]
+    member _.``Check if admin can edit event returns true when isAdmin = true``() =
+        let event = TestData.createEvent id
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient event
+            let eventId = System.Guid.Parse createdEvent.Event.Id
+            let! result = Queries.canEditEvent eventId true None "" fixture.dbContext
+
+            match result with
+            | Ok canEdit -> Assert.True(canEdit)
+            | Error e -> failwith $"Test failed: {e}"
+        }
+    [<Fact>]
+    member _.``Check if organizer can edit event returns true when OrganizerId matches employeeId``() =
+        let event = TestData.createEvent id
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient event
+            let eventId = System.Guid.Parse createdEvent.Event.Id
+            let employeeId = createdEvent.Event.OrganizerId
+            let! result = Queries.canEditEvent eventId false (Some employeeId) System.Guid.Empty fixture.dbContext
+    
+            match result with
+            | Ok canEdit -> Assert.True(canEdit)
+            | Error e -> failwith $"Test failed: {e}"
+        }
+        
+    [<Fact>]
+    member _.``Check if edit token can edit event returns true when EditToken matches``() =
+        let event =
+            TestData.createEvent id
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient event
+            let eventId = System.Guid.Parse createdEvent.Event.Id
+            let editToken = createdEvent.EditToken
+            let! result = Queries.canEditEvent eventId false None editToken fixture.dbContext
+    
+            match result with
+            | Ok canEdit -> Assert.True(canEdit)
+            | Error e -> failwith $"Test failed: {e}"
+        }
+    
+    [<Fact>]
+    member _.``Check if non-admin, non-organizer, and non-token holder cannot edit event``() =
+        let event = TestData.createEvent id
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient event
+            let eventId = System.Guid.Parse createdEvent.Event.Id
+            let! result = Queries.canEditEvent eventId false None System.Guid.Empty fixture.dbContext
+    
+            match result with
+            | Ok canEdit -> Assert.False(canEdit)
+            | Error e -> failwith $"Test failed: {e}"
+        }
+    
     [<Fact>]
     member _.``Querying non-existing participant gives no result``() =
         task {

--- a/Tests/Query.fs
+++ b/Tests/Query.fs
@@ -1,0 +1,34 @@
+namespace Tests.General
+
+open Tests
+open Xunit
+
+[<Collection("Database collection")>]
+type Queries(fixture: DatabaseFixture) =
+    let authenticatedClient =
+        fixture.getAuthedClient
+        
+    [<Fact>]
+    member _.``Querying non-existing participant gives no result``() =
+        task {
+            let! nonExistingParticipant = Queries.getParticipantForEvent (System.Guid.NewGuid()) "randomEmail@email.email" fixture.dbContext
+            
+            match nonExistingParticipant with
+            | Ok optionalParticipant -> Assert.True(optionalParticipant.IsNone)
+            | Error e ->  failwith $"Test failed: {e}"
+        }
+        
+    [<Fact>]
+    member _.``Querying existing participant gives result``() =
+        let event =
+            TestData.createEvent (fun e -> { e with IsExternal = false })
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient event
+            let! createdParticipant = Helpers.createParticipantAndGet authenticatedClient createdEvent.Event.Id
+            let! existingParticipant = Queries.getParticipantForEvent (System.Guid.Parse createdEvent.Event.Id) createdParticipant.Email fixture.dbContext
+            
+            match existingParticipant with
+            | Ok optionalParticipant -> Assert.True(optionalParticipant.IsSome)
+            | Error e -> failwith $"Test failed: {e}"
+        }
+

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -26,6 +26,7 @@
         <Compile Include="DateTimeCustom.fs" />
         <Compile Include="OfficeEvents.fs" />
         <Compile Include="SendEmailOnUpdateEvent.fs" />
+        <Compile Include="Query.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 

--- a/Tests/Utils/Models.fs
+++ b/Tests/Utils/Models.fs
@@ -31,7 +31,8 @@ type InnerEvent = { Id: string
                     Title: string
                     Location: string
                     OrganizerName: string
-                    OrganizerEmail: string }
+                    OrganizerEmail: string
+                    OrganizerId: int }
 
 type CreatedEvent =
     { EditToken: string
@@ -68,6 +69,7 @@ let innerEventDecoder: Decoder<InnerEvent> =
           Location = get.Required.Field "location" Decode.string
           OrganizerEmail = get.Required.Field "organizerEmail" Decode.string
           OrganizerName = get.Required.Field "organizerName" Decode.string
+          OrganizerId = get.Required.Field "organizerId" Decode.int
           })
 
 let createdEventDecoder: Decoder<CreatedEvent> =


### PR DESCRIPTION
**Problem**

Når en ansatt prøver å melde seg av et arrangement man ikke er påmeldt, kastes det en 500-feil. Jeg er litt usikker på akkurat hvordan denne situasjonen oppstår, men ser fra datadog at det har skjedd ganske mange ganger - og gjerne på eksterne arrangementer.

Problemet kommer fra querien `getParticipantForEvent` som returnerte en `Error` dersom den ikke fant den deltaker på det arrangementet. Denne querien ble brukt av `deleteParticipantFromEvent` http-handleren.

**Løsning**
Querien `getParticipantForEvent` er endret fra `Task<Result<Participant,exn>>` til `Task<Result<Participant option,exn>>`. Dersom den ikke finner en ansatt kan vi heller returnere en bedre feilmelding.

**Testing**
Vi hadde ingen måte å teste dette på, da det ikke var lagt opp til testing av database-queries. I tillegg til løsning har jeg:
- `deleteParticipantFromEvent` http-handleren
- Laget et enkelt oppsett for å teste queries.
- Lagt til en test på `getParticipantForEvent`
- Jeg la også inn noen tester på en annen query for å sjekke at denne nye test-riggen fungerte som forventet.
