### PR TITLE
Viser all tidsinformasjon på TimeInput og aligner knapper - preview

### DIFF
--- a/Frontend/src/components/Common/TimeInput/TimeInput.module.scss
+++ b/Frontend/src/components/Common/TimeInput/TimeInput.module.scss
@@ -5,7 +5,7 @@
   background-color: transparent;
   text-align: center;
   align-self: center;
-  width: 27px;
+  width: 35px;
   line-height: 1;
   @media #{$desktop} {
     width: 27px;

--- a/Frontend/src/components/EditEvent/EditEventContainer.module.scss
+++ b/Frontend/src/components/EditEvent/EditEventContainer.module.scss
@@ -10,7 +10,7 @@
 .buttonContainer {
   margin-top: 20px;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
 }
 
 .text {
@@ -19,9 +19,14 @@
 }
 
 .groupedButtons {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 10px;
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+    width: 100%;
+    @media #{$desktop} {
+        justify-content: space-between;
+        width: auto ;
+    }
 }
 
 .groupedButtons > button {

--- a/Frontend/src/components/EditEvent/EditEventContainer.module.scss
+++ b/Frontend/src/components/EditEvent/EditEventContainer.module.scss
@@ -8,9 +8,13 @@
 }
 
 .buttonContainer {
-  margin-top: 20px;
-  display: flex;
-  justify-content: flex-end;
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
+    @media #{$desktop} {
+        flex-direction: row;
+    }
 }
 
 .text {

--- a/Frontend/src/components/EditEvent/EditEventContainer.tsx
+++ b/Frontend/src/components/EditEvent/EditEventContainer.tsx
@@ -1,20 +1,16 @@
-import {useLayoutEffect, useEffect } from 'react';
+import { useLayoutEffect, useEffect } from 'react';
 import React from 'react';
-import {IEditEvent, toEditEvent, parseEditEvent, initialEditEvent} from 'src/types/event';
+import { IEditEvent, toEditEvent, parseEditEvent } from 'src/types/event';
 import { deleteEvent } from 'src/api/arrangementSvc';
 import { useHistory } from 'react-router';
 import { EditEvent } from './EditEvent/EditEvent';
 import style from './EditEventContainer.module.scss';
 import { eventsRoute, editTokenKey, previewEventRoute } from 'src/routing';
 import { hasLoaded } from 'src/remote-data';
-import {
-  useQuery,
-  useParam,
-} from 'src/utils/browser-state';
+import { useQuery, useParam } from 'src/utils/browser-state';
 import { useNotification } from 'src/components/NotificationHandler/NotificationHandler';
 import { Page } from 'src/components/Page/Page';
 import { Button } from 'src/components/Common/Button/Button';
-import { BlockLink } from 'src/components/Common/BlockLink/BlockLink';
 import { isValid } from 'src/types/validation';
 import { eventIdKey } from 'src/routing';
 import { ButtonWithPromptModal } from 'src/components/Common/ButtonWithConfirmModal/ButtonWithPromptModal';
@@ -22,15 +18,18 @@ import { useEvent } from 'src/hooks/cache';
 import { useGotoEventPreview } from 'src/hooks/history';
 import { useEditToken, useSavedEditableEvents } from 'src/hooks/saved-tokens';
 import classnames from 'classnames';
-import {useSetTitle} from "src/hooks/setTitle";
-import {Spinner} from "src/components/Common/Spinner/spinner";
-import {useSessionState} from "src/hooks/sessionState";
+import { useSetTitle } from 'src/hooks/setTitle';
+import { Spinner } from 'src/components/Common/Spinner/spinner';
+import { useSessionState } from 'src/hooks/sessionState';
 
 const useEditEvent = () => {
   const eventId = useParam(eventIdKey);
   const remoteEvent = useEvent(eventId);
 
-  const [editEvent, setEditEvent] = useSessionState<IEditEvent | undefined>(undefined, eventId);
+  const [editEvent, setEditEvent] = useSessionState<IEditEvent | undefined>(
+    undefined,
+    eventId
+  );
   useLayoutEffect(() => {
     if (hasLoaded(remoteEvent) && !editEvent) {
       setEditEvent(toEditEvent(remoteEvent.data));
@@ -56,7 +55,7 @@ const useSaveThisEditToken = ({ eventId }: { eventId: string }) => {
 export const EditEventContainer = () => {
   const { eventId, validEvent, editEvent, setEditEvent, errors } =
     useEditEvent();
-  useSetTitle(`Rediger ${editEvent?.title}`)
+  useSetTitle(`Rediger ${editEvent?.title}`);
 
   const { catchAndNotify } = useNotification();
   const history = useHistory();
@@ -67,7 +66,7 @@ export const EditEventContainer = () => {
   const editToken = useEditToken(eventId);
 
   if (!editEvent) {
-    return <Spinner />
+    return <Spinner />;
   }
 
   const onDeleteEvent = catchAndNotify(
@@ -82,7 +81,6 @@ export const EditEventContainer = () => {
       <h1 className={style.header}>Rediger arrangement</h1>
       <EditEvent eventResult={editEvent} updateEvent={setEditEvent} />
       <div className={style.buttonContainer}>
-        <BlockLink to={eventsRoute}>Avbryt</BlockLink>
         <div className={style.groupedButtons}>
           <ButtonWithPromptModal
             text={'Avlys arrangement'}

--- a/Frontend/src/components/EditEvent/EditEventContainer.tsx
+++ b/Frontend/src/components/EditEvent/EditEventContainer.tsx
@@ -21,6 +21,7 @@ import classnames from 'classnames';
 import { useSetTitle } from 'src/hooks/setTitle';
 import { Spinner } from 'src/components/Common/Spinner/spinner';
 import { useSessionState } from 'src/hooks/sessionState';
+import { BlockLink } from '../Common/BlockLink/BlockLink';
 
 const useEditEvent = () => {
   const eventId = useParam(eventIdKey);
@@ -81,6 +82,9 @@ export const EditEventContainer = () => {
       <h1 className={style.header}>Rediger arrangement</h1>
       <EditEvent eventResult={editEvent} updateEvent={setEditEvent} />
       <div className={style.buttonContainer}>
+        <BlockLink onLightBackground to={eventsRoute}>
+          Avbryt
+        </BlockLink>
         <div className={style.groupedButtons}>
           <ButtonWithPromptModal
             text={'Avlys arrangement'}

--- a/Frontend/src/components/PreviewEvent/PreviewEventContainer.tsx
+++ b/Frontend/src/components/PreviewEvent/PreviewEventContainer.tsx
@@ -18,19 +18,19 @@ import {
   isMaxParticipantsLimited,
   maxParticipantsLimit,
 } from 'src/types/event';
-import {useSetTitle} from "src/hooks/setTitle";
-import {appTitle} from "src/Constants";
-import {clearSessionState} from "../../hooks/sessionState";
+import { useSetTitle } from 'src/hooks/setTitle';
+import { appTitle } from 'src/Constants';
+import { clearSessionState } from '../../hooks/sessionState';
 
 export const PreviewEventContainer = () => {
   const { catchAndNotify } = useNotification();
   const history = useHistory();
-  useSetTitle(appTitle)
+  useSetTitle(appTitle);
 
   const eventId = useParam(eventIdKey);
   const editToken = useEditToken(eventId);
   const event = usePreviewEvent();
-  useSetTitle(`Forhåndsvisning ${event?.title}`)
+  useSetTitle(`Forhåndsvisning ${event?.title}`);
   if (!event) {
     return <div>Det finnes ingen event å forhåndsvise</div>;
   }
@@ -68,7 +68,7 @@ export const PreviewEventContainer = () => {
       </div>
       <div className={style.buttonContainer}>
         <Button color={'Secondary'} onClick={returnToEdit}>
-          Tilbake til redigering
+          Tilbake
         </Button>
         <Button onClick={putEditedEvent}>Lagre</Button>
       </div>

--- a/Frontend/src/components/PreviewEvent/PreviewNewEventContainer.tsx
+++ b/Frontend/src/components/PreviewEvent/PreviewNewEventContainer.tsx
@@ -17,8 +17,8 @@ import {
   isMaxParticipantsLimited,
   maxParticipantsLimit,
 } from 'src/types/event';
-import {useSetTitle} from "src/hooks/setTitle";
-import {clearSessionState} from "../../hooks/sessionState";
+import { useSetTitle } from 'src/hooks/setTitle';
+import { clearSessionState } from '../../hooks/sessionState';
 
 export const PreviewNewEventContainer = () => {
   const { catchAndNotify } = useNotification();
@@ -27,7 +27,7 @@ export const PreviewNewEventContainer = () => {
   const { saveEditableEvent } = useSavedEditableEvents();
 
   const event = usePreviewEvent();
-  useSetTitle(`Forhåndsvisning ${event?.title}`)
+  useSetTitle(`Forhåndsvisning ${event?.title}`);
   if (!event) {
     return <div>Det finnes ingen event å forhåndsvise</div>;
   }
@@ -50,7 +50,7 @@ export const PreviewNewEventContainer = () => {
       editToken,
     } = await postEvent(event, editUrlTemplate);
     saveEditableEvent({ eventId: id, editToken });
-    clearSessionState("createEvent")
+    clearSessionState('createEvent');
     history.push(
       shortname ? viewEventShortnameRoute(shortname) : viewEventRoute(id)
     );
@@ -70,9 +70,9 @@ export const PreviewNewEventContainer = () => {
       </div>
       <div className={style.buttonContainer}>
         <Button color={'Secondary'} onClick={returnToCreate}>
-          Tilbake til redigering
+          Tilbake
         </Button>
-        <Button onClick={postNewEvent}>Opprett arrangement</Button>
+        <Button onClick={postNewEvent}>Opprett</Button>
       </div>
     </Page>
   );


### PR DESCRIPTION
# Problem
- På IOS viste ikke alle tallene for start og slutttidspunkt.
- La oss merke til noen knapper som var alignet litt rart

# Løsning
- Gi litt mer lengde til `TimeInput` komponenten.
- Slette en usynlig lenke.
- Tweake litt på CSS rundt knapper så plassering ikke endres på desktop, men ligger riktig på IOs.

På IOS ser det slik ut nå:
 
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-09 at 09 31 17](https://user-images.githubusercontent.com/8441485/223968584-be70f384-767f-4b1e-be6d-d71a282464df.png)

<img width="369" alt="image" src="https://user-images.githubusercontent.com/8441485/223969252-10c60201-cdd0-412c-8e4e-858d33f43f0f.png">

