### PR TITLE
Sort upcoming events by startdate, previous events by end date - preview

### DIFF
--- a/Frontend/src/components/ViewEventsCards/EventCardElement.module.scss
+++ b/Frontend/src/components/ViewEventsCards/EventCardElement.module.scss
@@ -1,6 +1,15 @@
 @import 'src/style/constants';
 @import 'src/style/fonts';
 
+.icon {
+    height: 32px;
+    width: 32px;
+    margin-right: 10px;
+    @media #{$desktop} {
+        margin-right: 3px;
+    }
+}
+
 .card {
   border: solid 1px white;
   padding: 15px;
@@ -26,7 +35,7 @@
   }
 
   &:hover .officeIcon path {
-    stroke: black;
+    stroke: white;
   }
 
   &:hover .externalIcon path:first-of-type {

--- a/Frontend/src/components/ViewEventsCards/EventCardElement.tsx
+++ b/Frontend/src/components/ViewEventsCards/EventCardElement.tsx
@@ -122,7 +122,7 @@ export const EventCardElement = ({ eventId, event }: IProps) => {
       {event.offices && (
         <div className={style.location}>
           <div className={style.officeIcon}>
-            <OfficeIcon color="white" />
+            <OfficeIcon color="white" className={style.icon} />
           </div>
 
           <div className={style.iconText}>

--- a/Frontend/src/components/ViewEventsCards/ViewEventsCardsContainer.tsx
+++ b/Frontend/src/components/ViewEventsCards/ViewEventsCardsContainer.tsx
@@ -60,7 +60,7 @@ export const ViewEventsCardsContainer = () => {
 
   useEffect(
     () => {
-      setFilteredEvents(sortEvents(fetchedEvents));
+      setFilteredEvents(fetchedEvents);
     },
     // https://github.com/facebook/react/issues/14476 Dan Abramov says this is OK
     [JSON.stringify(fetchedEvents)]
@@ -103,8 +103,3 @@ const eventMapToList = (
     hasLoaded(event) ? [[id, event.data]] : []
   );
 
-const sortEvents = (events: [string, IEvent][]) => {
-  return events.sort(([idA, a], [idB, b]) =>
-    isInOrder({ first: a.start, last: b.start }) ? 1 : -1
-  );
-};

--- a/Frontend/src/hooks/cache.ts
+++ b/Frontend/src/hooks/cache.ts
@@ -1,5 +1,5 @@
 import { cachedRemoteData, RemoteData } from 'src/remote-data';
-import { IEvent, parseEventViewModel } from 'src/types/event';
+import {IEvent, IEventViewModel, parseEventViewModel} from 'src/types/event';
 import { useCallback, useMemo } from 'react';
 import {
   getEvent,
@@ -19,6 +19,8 @@ import { getEmailNameAndDepartment } from 'src/api/employeeSvc';
 import { getEmployeeId } from 'src/auth';
 import { EventState } from 'src/components/ViewEventsCards/ParticipationState';
 import { OfficeEvent } from '../types/OfficeEvent';
+import {isInOrder} from "../types/date-time";
+import { WithId } from 'src/types';
 
 //**  Event  **//
 
@@ -39,7 +41,7 @@ export const useEvents = (): Map<string, RemoteData<IEvent>> => {
     useCallback(async () => {
       const futureEvents = await getEvents();
       const pastEvents = await getPastEvents();
-      const allEvents = [...futureEvents, ...pastEvents];
+      const allEvents = [...sortEventsByStartDate(futureEvents), ...sortEventsByEndDate(pastEvents)];
       return allEvents.map(({ id, ...event }) => [
         id,
         parseEventViewModel(event),
@@ -146,4 +148,16 @@ export const useEmailNameAndDepartment = () => {
       return await getEmailNameAndDepartment(employeeId);
     }, [employeeId]),
   });
+};
+
+const sortEventsByStartDate = (events: WithId<IEventViewModel>[]) => {
+    return events.sort((a, b) =>
+        isInOrder({ first: a.startDate, last: b.startDate }) ? -1 : 1
+    );
+};
+
+const sortEventsByEndDate = (events: WithId<IEventViewModel>[]) => {
+    return events.sort((a, b) =>
+        isInOrder({ first: a.startDate, last: b.startDate }) ? 1 : -1
+    );
 };


### PR DESCRIPTION
Arrangement sortering var litt rar. Slik som sorteringen fungerte fra før er at arrangementene som er lengst frem i tid vises først. Altså at de som tar sted i desember 2023 er øverst.

Denne endringen sorterer kommende og tidligere arrangementer annerledes.
Nå sorteres kommende arrangementer etter startdato. Det betyr at arrangementet som finner sted først, vises først.

Tidligere arrangementer sorteres etter sluttdato. Som betyr at de som tok sted sist, vises øverst over kommende arrangementer.

(Fikset også et ikon som manglet styling)