### PR TITLE
Redirect til login ved HTTP 403 fra avmeldingssiden - preview

### DIFF
--- a/Frontend/src/components/CancelParticipant/CancelParticipant.module.scss
+++ b/Frontend/src/components/CancelParticipant/CancelParticipant.module.scss
@@ -13,6 +13,11 @@
   color: black;
 }
 
+.errorText {
+  @extend .text;
+  margin-top: 130px;
+}
+
 .buttonContainer {
   margin-top: 50px;
   max-width: 500px;

--- a/Frontend/src/components/CancelParticipant/CancelParticipant.tsx
+++ b/Frontend/src/components/CancelParticipant/CancelParticipant.tsx
@@ -20,6 +20,7 @@ import { useSavedParticipations } from 'src/hooks/saved-tokens';
 import { useSetTitle } from 'src/hooks/setTitle';
 import { appTitle } from 'src/Constants';
 import { Spinner } from 'src/components/Common/Spinner/spinner';
+import { authenticateUser, isAuthenticated, needsToAuthenticate } from 'src/auth';
 
 export const CancelParticipant = () => {
   const eventId = useParam(eventIdKey);
@@ -69,14 +70,11 @@ export const CancelParticipant = () => {
   });
 
   if (isBad(remoteEvent)) {
-    return (
-      <div>
-        Ugyldig url!{' '}
-        <span role="img" aria-label="sad emoji">
-          😔
-        </span>
-      </div>
-    );
+    if (!isAuthenticated() && needsToAuthenticate(remoteEvent.statusCode)) {
+      authenticateUser();
+      return <p className={style.errorText}>Redirigerer til innlogging</p>;
+    }
+    return <p className={style.errorText}>{remoteEvent.userMessage}</p>;
   }
 
   if (!hasLoaded(remoteEvent)) {


### PR DESCRIPTION
**Airtable**
https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/rec2XYp3wfRWyrQ3v?blocks=hide

**Issue**
Hvis et event ikke er eksternt og du ikke er innlogget, så får du nå bare et trist smileyfjes når du klikker deg inn på lenken for avmelding i påmeldingseposten. 

Mange trodde dette betydde at de hadde meldt seg av, men faktisk så skyldtes det at brukeren ikke har vært autentisert og backend svarer da med HTTP 403 (hvis ikke eventet er eksternt).

**Løsning**
Vi bruker tilsvarende logikk som for `ViewEventContainer`, hvor om status fra `RemoteData` er `ERROR` og backend svarer med  statuskode `403`, samtidig som brukeren ikke er autentisert, så kjører vi igang autentiseringsløypen (redirecter til auth0).

Ved andre tilfeller hvor det er `ERROR` fra backend, så viser vi nå den faktisk meldingen, istedenfor en usynlig hvit tekst på hvit bakgrunn som sier `Ugyldig URL`, sammen med et trist smileyfjes.