### PR TITLE
Lenker til event i flere eposter - preview

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -45,7 +45,7 @@ let private createEditUrl (redirectUrlTemplate: string) (event: Models.Event) =
 
 let private createCancelUrl (redirectUrlTemplate: string) (participant: Participant) =
     let decodedUrlTemplate = HttpUtility.UrlDecode redirectUrlTemplate
-    redirectUrlTemplate
+    decodedUrlTemplate
         .Replace("{eventId}", participant.EventId.ToString())
         .Replace("{email}", participant.Email |> Uri.EscapeDataString)
         .Replace("{cancellationToken}", participant.CancellationToken.ToString())

--- a/Arrangement-Svc/Models/Models.fs
+++ b/Arrangement-Svc/Models/Models.fs
@@ -130,9 +130,9 @@ type EventWriteModel =
       CloseRegistrationTime: string option
       ParticipantQuestions: string list
       Program: string option
-      ViewUrl: string option
+      ViewUrlTemplate: string
       EditUrlTemplate: string
-      CancelParticipationUrlTemplate: string option
+      CancelParticipationUrlTemplate: string
       HasWaitingList: bool
       IsExternal: bool
       IsHidden: bool
@@ -163,9 +163,9 @@ module EventWriteModel =
               ParticipantQuestions = get.Required.Field "participantQuestions"
                                          (Decode.list Decode.string |> Decode.andThen Validate.participantQuestions)
               Program = get.Optional.Field "program" Decode.string
-              ViewUrl = get.Optional.Field "viewUrl" Decode.string
+              ViewUrlTemplate = get.Required.Field "viewUrlTemplate" Decode.string
               EditUrlTemplate = get.Required.Field "editUrlTemplate" Decode.string
-              CancelParticipationUrlTemplate = get.Optional.Field "cancelParticipationUrlTemplate" Decode.string
+              CancelParticipationUrlTemplate = get.Required.Field "cancelParticipationUrlTemplate" Decode.string
               HasWaitingList = get.Required.Field "hasWaitingList" Decode.bool
               IsExternal = get.Required.Field "isExternal" Decode.bool
               IsHidden = get.Required.Field "isHidden" Decode.bool
@@ -334,6 +334,7 @@ type ParticipantWriteModel =
     { Name: string
       Department: string
       ParticipantAnswers: string list
+      ViewUrlTemplate: string
       CancelUrlTemplate: string
     }
 
@@ -346,6 +347,7 @@ module ParticipantWriteModel =
         Department = get.Required.Field "department" Decode.string
         ParticipantAnswers = get.Required.Field "participantAnswers"
                                  (Decode.list Decode.string |> Decode.andThen Validate.participantAnswers)
+        ViewUrlTemplate = get.Required.Field "viewUrlTemplate" Decode.string
         CancelUrlTemplate = get.Required.Field "cancelUrlTemplate" Decode.string
       })
 

--- a/Frontend/src/api/arrangementSvc.ts
+++ b/Frontend/src/api/arrangementSvc.ts
@@ -19,13 +19,12 @@ import { cancelParticipantRoute } from 'src/routing';
 import { OfficeEvent, OfficeEventDecoder } from '../types/OfficeEvent';
 
 export const postEvent = (
-  event: IEvent,
-  editUrlTemplate: string
+  event: IEvent
 ): Promise<INewEventViewModel> =>
   post({
     host: '',
     path: '/api/events',
-    body: toEventWriteModel(event, editUrlTemplate),
+    body: toEventWriteModel(event),
   });
 
 export const putEvent = (
@@ -33,17 +32,10 @@ export const putEvent = (
   event: IEvent,
   editToken?: string
 ): Promise<IEventViewModel> => {
-  const cancelParticipationUrlTemplate =
-    document.location.origin +
-    cancelParticipantRoute({
-      eventId: '{eventId}',
-      email: '{email}',
-      cancellationToken: '{cancellationToken}',
-    });
   return put({
     host: '',
     path: `/api/events/${eventId}${queryStringStringify({ editToken })}`,
-    body: toEventWriteModel(event, '', cancelParticipationUrlTemplate),
+    body: toEventWriteModel(event),
   });
 };
 
@@ -115,16 +107,16 @@ export const getWaitinglistSpot = (
   });
 
 export const postParticipant = (
+  event: IEvent,
   eventId: string,
   participant: IParticipant,
-  cancelUrlTemplate: string
 ): Promise<INewParticipantViewModel> =>
   post({
     host: '',
     path: `/api/events/${eventId}/participants/${encodeURIComponent(
       toEmailWriteModel(participant.email)
     )}`,
-    body: toParticipantWriteModel(participant, cancelUrlTemplate),
+    body: toParticipantWriteModel(participant, event),
   });
 
 export const deleteParticipant = ({

--- a/Frontend/src/components/PreviewEvent/PreviewNewEventContainer.tsx
+++ b/Frontend/src/components/PreviewEvent/PreviewNewEventContainer.tsx
@@ -43,12 +43,10 @@ export const PreviewNewEventContainer = () => {
   } plasser`;
 
   const postNewEvent = catchAndNotify(async () => {
-    const editUrlTemplate =
-      document.location.origin + editEventRoute('{eventId}', '{editToken}');
     const {
       event: { id, shortname },
       editToken,
-    } = await postEvent(event, editUrlTemplate);
+    } = await postEvent(event);
     saveEditableEvent({ eventId: id, editToken });
     clearSessionState('createEvent');
     history.push(

--- a/Frontend/src/components/ViewEvent/AddParticipant.tsx
+++ b/Frontend/src/components/ViewEvent/AddParticipant.tsx
@@ -12,7 +12,7 @@ import { parseEditEmail } from 'src/types/email';
 import { Button } from 'src/components/Common/Button/Button';
 import { IEvent } from 'src/types/event';
 import { useNotification } from 'src/components/NotificationHandler/NotificationHandler';
-import { cancelParticipantRoute, confirmParticipantRoute } from 'src/routing';
+import { confirmParticipantRoute } from 'src/routing';
 import { postParticipant } from 'src/api/arrangementSvc';
 import { isValid } from 'src/types/validation';
 import { useHistory } from 'react-router';
@@ -64,23 +64,15 @@ export const AddParticipant = ({
   const { saveParticipation } = useSavedParticipations();
   const participate = catchAndNotify(async () => {
     if (validParticipant) {
-      const cancelUrlTemplate =
-        document.location.origin +
-        cancelParticipantRoute({
-          eventId: '{eventId}',
-          email: '{email}',
-          cancellationToken: '{cancellationToken}',
-        });
-
       setWaitingOnParticipation(true);
 
       const {
         participant: { email = '' },
         cancellationToken,
       } = await postParticipant(
+        event,
         eventId,
-        validParticipant,
-        cancelUrlTemplate
+        validParticipant
       ).catch((e) => {
         setWaitingOnParticipation(false);
         throw e;

--- a/Frontend/src/routing.ts
+++ b/Frontend/src/routing.ts
@@ -1,5 +1,6 @@
 import { useRouteMatch } from 'react-router';
 import { queryStringStringify } from 'src/utils/browser-state';
+import { IEvent } from "./types/event";
 
 export const eventIdKey = 'eventId';
 export const emailKey = 'email';
@@ -15,12 +16,23 @@ export const officeEventsMonthKey = 'date';
 
 export const viewEventShortnameRoute = (shortname: string) => `/${shortname}`;
 export const viewEventRoute = (eventId: string) => `/events/${eventId}`;
+
+export const createViewUrlTemplate = (event: IEvent) => {
+  const hostAndProtocol = document.location.origin;
+  return event.shortname
+    ? hostAndProtocol + viewEventShortnameRoute("{shortname}")
+    : hostAndProtocol + viewEventRoute("{eventId}");
+};
+
 export const officeEventRoute = (date: string) => `/office-events/${date}`;
 
 export const editEventRoute = (eventId: string, editToken?: string) =>
   `/events/${eventId}/edit${queryStringStringify({
     [editTokenKey]: editToken,
   })}`;
+
+export const editUrlTemplate =
+  document.location.origin + editEventRoute('{eventId}', '{editToken}');
 
 export const previewEventRoute = (eventId: string) =>
   `/events/${eventId}/preview`;
@@ -45,6 +57,14 @@ export const cancelParticipantRoute = ({
   `/events/${eventId}/cancel/${email}${queryStringStringify({
     [cancellationTokenKey]: cancellationToken,
   })}`;
+
+export const cancelParticipationUrlTemplate =
+  document.location.origin +
+  cancelParticipantRoute({
+    eventId: '{eventId}',
+    email: '{email}',
+    cancellationToken: '{cancellationToken}',
+  });
 
 export const useIsEditingRoute = () => {
   let routematch = useRouteMatch(editEventRoute(':' + eventIdKey));

--- a/Frontend/src/types/event.ts
+++ b/Frontend/src/types/event.ts
@@ -43,7 +43,13 @@ import {
 } from 'src/types/date';
 import { parseName } from 'src/types/participant';
 
-import { viewEventShortnameRoute } from 'src/routing';
+import {
+  cancelParticipantRoute, cancelParticipationUrlTemplate, createViewUrlTemplate,
+  editEventRoute,
+  editUrlTemplate,
+  viewEventRoute,
+  viewEventShortnameRoute
+} from 'src/routing';
 import { toEditTime } from 'src/types/time';
 
 export interface INewEventViewModel {
@@ -92,7 +98,7 @@ export interface IEventWriteModel {
   organizerName: string;
   organizerEmail: string;
   maxParticipants?: number;
-  viewUrl?: string;
+  viewUrlTemplate: string;
   editUrlTemplate: string;
   cancelParticipationUrlTemplate: string;
   participantQuestions: string[];
@@ -220,9 +226,7 @@ export const parseEditEvent = ({
 };
 
 export const toEventWriteModel = (
-  event: IEvent,
-  editUrlTemplate: string = '',
-  cancelParticipationUrlTemplate: string = ''
+  event: IEvent
 ): IEventWriteModel => ({
   ...event,
   maxParticipants: isMaxParticipantsLimited(event.maxParticipants)
@@ -238,9 +242,9 @@ export const toEventWriteModel = (
   organizerEmail: toEmailWriteModel(event.organizerEmail),
   startDate: event.start,
   endDate: event.end,
-  viewUrl: event.shortname && urlFromShortname(event.shortname),
-  editUrlTemplate,
-  cancelParticipationUrlTemplate,
+  viewUrlTemplate: createViewUrlTemplate(event),
+  editUrlTemplate: editUrlTemplate,
+  cancelParticipationUrlTemplate: cancelParticipationUrlTemplate
 });
 
 export const parseEventViewModel = (eventView: IEventViewModel): IEvent => {

--- a/Frontend/src/types/participant.ts
+++ b/Frontend/src/types/participant.ts
@@ -5,10 +5,13 @@ import {
   toEditEmail,
   parseEditEmail,
 } from './email';
+import { cancelParticipationUrlTemplate, createViewUrlTemplate } from "../routing";
+import { IEvent } from "./event";
 
 export interface IParticipantWriteModel {
   name: string;
   participantAnswers: string[];
+  viewUrlTemplate: string;
   cancelUrlTemplate: string;
 }
 
@@ -52,11 +55,12 @@ export interface IEditParticipant {
 
 export const toParticipantWriteModel = (
   participant: IParticipant,
-  cancelUrlTemplate: string = ''
+  event: IEvent,
 ): IParticipantWriteModel => {
   return {
     ...participant,
-    cancelUrlTemplate,
+    viewUrlTemplate: createViewUrlTemplate(event),
+    cancelUrlTemplate: cancelParticipationUrlTemplate,
   };
 };
 

--- a/Tests/Utils/Generator.fs
+++ b/Tests/Utils/Generator.fs
@@ -93,7 +93,7 @@ let generateEvent () : Models.EventWriteModel =
           else
               "{shortname}"
       EditUrlTemplate = "{eventId}{editToken}"
-      CancelParticipationUrlTemplate = Some "/events/{eventId}/cancel/{email}?cancellationToken={cancellationToken}"
+      CancelParticipationUrlTemplate = "/events/{eventId}/cancel/{email}?cancellationToken={cancellationToken}"
       HasWaitingList = faker.Hacker.Random.Bool()
       IsExternal = faker.Hacker.Random.Bool()
       IsHidden =
@@ -132,4 +132,5 @@ let generateParticipant (number_of_questions: int): Models.ParticipantWriteModel
       ParticipantAnswers =
           [0..number_of_questions]
           |> List.map (fun _ -> faker.Lorem.Sentence())
-      CancelUrlTemplate = "{eventId}{email}{cancellationToken}" }
+      CancelUrlTemplate = "{eventId}{email}{cancellationToken}"
+      ViewUrlTemplate = "{eventId}" }

--- a/Tests/Utils/Generator.fs
+++ b/Tests/Utils/Generator.fs
@@ -87,11 +87,11 @@ let generateEvent () : Models.EventWriteModel =
               None
           else
               Some(faker.Lorem.Paragraph()[0..99])
-      ViewUrl =
+      ViewUrlTemplate =
           if faker.Random.Number(0, 5) <> 0 then
-              None
+              "{eventId}"
           else
-              Some(faker.Lorem.Word())
+              "{shortname}"
       EditUrlTemplate = "{eventId}{editToken}"
       CancelParticipationUrlTemplate = Some "/events/{eventId}/cancel/{email}?cancellationToken={cancellationToken}"
       HasWaitingList = faker.Hacker.Random.Bool()


### PR DESCRIPTION
**Airtable**
https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/recYufAg7uJFjaNKe?blocks=hide

**Issue**
I e-posten påmeldte deltakere får, så er det kun en lenke til avmelding fra arrangement, men ikke til selve arrangementsiden (selv om du kan trykke deg frem via avmeldingssiden). Det var ytret ønske om å også lenke til selve hovedsiden, slik at event-info er lettere tilgjengelig. 

**Konkrete endringer**
- E-postbekreftelse ved påmelding: Ingen tekstendring, men tittelen på eventen i bodyen er en lenke til event-siden
- E-postbekreftelse ved venteliste: Ingen tekstendring, men tittelen på eventen i bodyen er en lenke til event-siden
- Mail til arrangør ved opprettelse av event: Tidligere viste den en tekst med lenke til event-siden kun om du hadde definert et `shortname`, men nå vil den alltid vise denne teksten (enten du har `shortname` eller ikke)

**Forklaring**
Det er alltid frontend som genererer enten en lenke eller en template-lenke, som så backend bruker i e-postene (ved å første å replace placeholdere hvis det er en template-URL, eller bruker URL direkte om det ikke er template). Disse URLene lagres dog ikke i databasen, så vi har kun tilgang til disse i de tilfeller hvor det sendes fra frontend.

Vi har disse lenkene ved opprettelse/endring av event og påmeldingsaktivitet:
- Visningslenke/ViewUrl: Denne var tidligere ikke en templateUrl, men ble laget ferdig i frontend, og ble kun laget hvis en event hadde et shortname. Nå er dette endret til å være et påkrevd felt `viewUrlTemplate`, som lager lenke av enten `eventId` eller `shortname` (hvis det finnes). Brukes i epost til arrangør ved opprettelse av event, og til deltakere som melder seg på / havner på venteliste.
- Avmeldingslenke/CancelUrl: Lenke til hvor en deltaker kan melde seg av.  
- Redigeringslenke/EditUrl: Lenke til arrangør for redigering av event.

**Alternativ løsning**
Jeg har lagt meg på samme løsning som tidligere her (bare endret viewUrl -> `viewUrlTemplate` og gjort alle template-URL påkrevd), men jeg lurer på om et bedre alternativ på sikt ville være å generert disse lenkene i backend. Det er stabile URLer som bygges opp med data som finnes i en `Event` eller `Participant` (som finnes i DB), og da vil vi alltid ha tilgang til informasjonen vi trenger for å lage disse lenkene, istedenfor å være avhengig av at dette sendes inn fra frontend (per nå mangler dette feks. ved avmelding, hvor noen på venteliste blir påmeldt og eposten da refererer til en avmeldingslenke i en tidligere e-post).

Eneste fordelene jeg ser med å bruke frontend til URL-genereringen er:
- Den henter ut host-location, som gjør at det lenkes til riktig miljø i eposten uansett om du bruker `localhost`, et preview-miljø, dev eller prod. Om dette flyttes til backend, så skiller vi typisk kun på dev og prod (men kan vel også støtte `localhost` for ting som kjøres opp lokalt vha. `appsettings.Development.json`).
- Frontend har definert routingen som brukes i appen, så vi får dermed en større nærhet mellom hvor routen er definert og hvor vi genererer lenkene som til slutt peker tilbake til disse. Det er likevel veldig stabile URLer, og det burde ikke være et problem å endre dette på tvers av frontend og backend om det en dag endres.