### PR TITLE
Fikset logo som legger seg over Rediger-knappen på mindre skjermer - preview

### DIFF
--- a/Frontend/src/components/Common/Header/Header.module.scss
+++ b/Frontend/src/components/Common/Header/Header.module.scss
@@ -1,8 +1,13 @@
 @import 'src/style/colors';
+@import 'src/style/constants';
+
 .header {
   position: absolute;
   width: 100%;
   padding-top: 3em;
+  @media #{$mobile}, (max-width:$tabletMaxWidth) {
+    padding-top: 1em;
+  }
   z-index: 100;
 }
 


### PR DESCRIPTION
**Airtable**: https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/rec2aJfP18M7LmP1j?blocks=hide (Veronika meldte om denne i teamkanalen vår).

**Løsning**: Lagt til mindre padding på toppen for mindre skjermer.

