### PR TITLE
Håndtere svar med komma i seg - preview

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -726,7 +726,7 @@ let createCsvString (event: Models.Event) (questions: ParticipantQuestion list) 
         let department =
             participant.Department
             |> Option.defaultValue ""
-        builder.Append($"{employeeId}, {participant.Name}, {participant.Email}, {department}, {answers}\n") |> ignore
+        builder.Append($"{employeeId},{participant.Name},{participant.Email},{department},\"{answers}\"\n") |> ignore
 
     let builder = System.Text.StringBuilder()
 


### PR DESCRIPTION
Airtable: https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/rec0uI8AQjh5mf75w?blocks=hide

Løsning: Lagt på fnutter rundt teksten på svarene. Fant i tillegg ut at fnutter kun fungerer dersom vi ikke har mellomrom før delimiteren/komma, dvs mellom cellene i en csv. Har derfor fjernet dem her.