### PR TITLE
Oppdatert ikon for location og office - preview

### DIFF
--- a/Frontend/src/components/Common/Icons/LocationIcon.tsx
+++ b/Frontend/src/components/Common/Icons/LocationIcon.tsx
@@ -16,11 +16,10 @@ export const LocationIcon = ({ color, className }: IconProps) => {
       className={className}>
       <path
         d="M8.99755 1C4.58072 1 1 4.57368 1 8.9758C1 13.7653 8.99755 25 8.99755 25C8.99755 25 17 13.6439 17 8.9758C17 4.57368 13.4193 1 8.99755 1ZM8.99755 11.0628C7.34552 11.0628 6.00444 9.72128 6.00444 8.07476C6.00444 6.42823 7.34552 5.08673 8.99755 5.08673C10.6545 5.08673 11.9956 6.42823 11.9956 8.07476C11.9956 9.72128 10.6545 11.0628 8.99755 11.0628Z"
-        stroke="#0E0E0E"
+        stroke={color}
         strokeMiterlimit="10"
         strokeLinecap="round"
         strokeLinejoin="round"
-        fill={color}
       />
     </svg>
   );

--- a/Frontend/src/components/Common/Icons/OfficeIcon.tsx
+++ b/Frontend/src/components/Common/Icons/OfficeIcon.tsx
@@ -5,7 +5,7 @@ interface IconProps {
   className?: string;
 }
 
-export const OfficeIcon = ({ color, className }: IconProps) => {
+export const OfficeIcon_old = ({ color, className }: IconProps) => {
   return (
     <svg
       width="21"
@@ -24,3 +24,47 @@ export const OfficeIcon = ({ color, className }: IconProps) => {
     </svg>
   );
 };
+
+export const OfficeIcon = ({ color, className }: IconProps) => {
+    if (Math.random() > 0.5) {
+        return (
+            <svg
+                width="18"
+                height="24"
+                viewBox="0 0 18 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className={className}
+            >
+                <path d="M14 1H1V20H14V1Z" stroke={color} strokeWidth="0.5"/>
+                <path d="M12 4H9V7H12V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
+                <path d="M6 4H3V7H6V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
+                <path d="M6 9H3V12H6V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
+                <path d="M12 9H9V12H12V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
+                <path d="M9 14H6V20H9V14Z" stroke={color} strokeWidth="0.5"/>
+                <path d="M13.9991 14C12.3428 14 11 15.3401 11 16.9909C11 18.787 13.9991 23 13.9991 23C13.9991 23 17 18.7415 17 16.9909C17 15.3401 15.6572 14 13.9991 14ZM13.9991 17.7735C13.3796 17.7735 12.8767 17.2705 12.8767 16.653C12.8767 16.0356 13.3796 15.5325 13.9991 15.5325C14.6204 15.5325 15.1233 16.0356 15.1233 16.653C15.1233 17.2705 14.6204 17.7735 13.9991 17.7735Z" fill="white" stroke={color} strokeWidth="0.5" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round"/>
+                <circle cx="14" cy="16.6499" r="1" fill="#0E0E0E"/>
+            </svg>
+        );
+    } else {
+        return (
+            <svg
+                width="18"
+                height="24"
+                viewBox="0 0 18 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className={className}
+            >
+                <path d="M14 1H1V20H14V1Z" stroke={color} strokeWidth="0.5"/>
+                <path d="M12 4H9V7H12V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
+                <path d="M6 4H3V7H6V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
+                <path d="M6 9H3V12H6V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
+                <path d="M12 9H9V12H12V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
+                <path d="M9 14H6V20H9V14Z" stroke={color} strokeWidth="0.5"/>
+                <path d="M13.9991 14C12.3428 14 11 15.3401 11 16.9909C11 18.787 13.9991 23 13.9991 23C13.9991 23 17 18.7415 17 16.9909C17 15.3401 15.6572 14 13.9991 14ZM13.9991 17.7735C13.3796 17.7735 12.8767 17.2705 12.8767 16.653C12.8767 16.0356 13.3796 15.5325 13.9991 15.5325C14.6204 15.5325 15.1233 16.0356 15.1233 16.653C15.1233 17.2705 14.6204 17.7735 13.9991 17.7735Z" fill="#0E0E0E" stroke={color} strokeWidth="0.5" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round"/>
+                <circle cx="14" cy="16.6499" r="1" fill="white"/>
+            </svg>
+        );
+    }
+}

--- a/Frontend/src/components/Common/Icons/OfficeIcon.tsx
+++ b/Frontend/src/components/Common/Icons/OfficeIcon.tsx
@@ -5,66 +5,32 @@ interface IconProps {
   className?: string;
 }
 
-export const OfficeIcon_old = ({ color, className }: IconProps) => {
+export const OfficeIcon = ({color, className}: IconProps) => {
   return (
     <svg
-      width="21"
+      width="18"
       height="24"
-      viewBox="0 0 21 24"
+      viewBox="0 0 18 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={className}
-      shapeRendering="crispEdges">
-      <path d="M20 1H1V23H20V1Z" stroke={color} strokeWidth="0.5" />
-      <path d="M9.5 4H6.5V8H9.5V4Z" stroke={color} strokeWidth="0.5" />
-      <path d="M9.5 10H6.5V14H9.5V10Z" stroke={color} strokeWidth="0.5" />
-      <path d="M15.5 4H12.5V8H15.5V4Z" stroke={color} strokeWidth="0.5" />
-      <path d="M15.5 10H12.5V14H15.5V10Z" stroke={color} strokeWidth="0.5" />
-      <path d="M12.5 16H8.5V23H12.5V16Z" stroke={color} strokeWidth="0.5" />
+    >
+      <path d="M14 1H1V20H14V1Z" stroke={color} strokeWidth="0.5"/>
+      <path d="M12 4H9V7H12V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
+      <path d="M6 4H3V7H6V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
+      <path d="M6 9H3V12H6V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
+      <path d="M12 9H9V12H12V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
+      <path d="M9 14H6V20H9V14Z" stroke={color} strokeWidth="0.5"/>
+      <path
+        d="M13.9991 14C12.3428 14 11 15.3401 11 16.9909C11 18.787 13.9991 23 13.9991 23C13.9991 23 17 18.7415 17 16.9909C17 15.3401 15.6572 14 13.9991 14ZM13.9991 17.7735C13.3796 17.7735 12.8767 17.2705 12.8767 16.653C12.8767 16.0356 13.3796 15.5325 13.9991 15.5325C14.6204 15.5325 15.1233 16.0356 15.1233 16.653C15.1233 17.2705 14.6204 17.7735 13.9991 17.7735Z"
+        fill="#0E0E0E"
+        stroke={color}
+        strokeWidth="0.5"
+        strokeMiterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="14" cy="16.6499" r="1" fill="white"/>
     </svg>
   );
-};
-
-export const OfficeIcon = ({ color, className }: IconProps) => {
-    if (Math.random() > 0.5) {
-        return (
-            <svg
-                width="18"
-                height="24"
-                viewBox="0 0 18 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                className={className}
-            >
-                <path d="M14 1H1V20H14V1Z" stroke={color} strokeWidth="0.5"/>
-                <path d="M12 4H9V7H12V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
-                <path d="M6 4H3V7H6V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
-                <path d="M6 9H3V12H6V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
-                <path d="M12 9H9V12H12V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
-                <path d="M9 14H6V20H9V14Z" stroke={color} strokeWidth="0.5"/>
-                <path d="M13.9991 14C12.3428 14 11 15.3401 11 16.9909C11 18.787 13.9991 23 13.9991 23C13.9991 23 17 18.7415 17 16.9909C17 15.3401 15.6572 14 13.9991 14ZM13.9991 17.7735C13.3796 17.7735 12.8767 17.2705 12.8767 16.653C12.8767 16.0356 13.3796 15.5325 13.9991 15.5325C14.6204 15.5325 15.1233 16.0356 15.1233 16.653C15.1233 17.2705 14.6204 17.7735 13.9991 17.7735Z" fill="white" stroke="#0E0E0E" strokeWidth="0.5" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round"/>
-                <circle cx="14" cy="16.6499" r="1" fill="#0E0E0E"/>
-            </svg>
-        );
-    } else {
-        return (
-            <svg
-                width="18"
-                height="24"
-                viewBox="0 0 18 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                className={className}
-            >
-                <path d="M14 1H1V20H14V1Z" stroke={color} strokeWidth="0.5"/>
-                <path d="M12 4H9V7H12V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
-                <path d="M6 4H3V7H6V4Z" fill="white" stroke={color} strokeWidth="0.5"/>
-                <path d="M6 9H3V12H6V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
-                <path d="M12 9H9V12H12V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
-                <path d="M9 14H6V20H9V14Z" stroke={color} strokeWidth="0.5"/>
-                <path d="M13.9991 14C12.3428 14 11 15.3401 11 16.9909C11 18.787 13.9991 23 13.9991 23C13.9991 23 17 18.7415 17 16.9909C17 15.3401 15.6572 14 13.9991 14ZM13.9991 17.7735C13.3796 17.7735 12.8767 17.2705 12.8767 16.653C12.8767 16.0356 13.3796 15.5325 13.9991 15.5325C14.6204 15.5325 15.1233 16.0356 15.1233 16.653C15.1233 17.2705 14.6204 17.7735 13.9991 17.7735Z" fill="#0E0E0E" stroke={color} strokeWidth="0.5" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round"/>
-                <circle cx="14" cy="16.6499" r="1" fill="white"/>
-            </svg>
-        );
-    }
 }

--- a/Frontend/src/components/Common/Icons/OfficeIcon.tsx
+++ b/Frontend/src/components/Common/Icons/OfficeIcon.tsx
@@ -42,7 +42,7 @@ export const OfficeIcon = ({ color, className }: IconProps) => {
                 <path d="M6 9H3V12H6V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
                 <path d="M12 9H9V12H12V9Z" fill="white" stroke={color} strokeWidth="0.5"/>
                 <path d="M9 14H6V20H9V14Z" stroke={color} strokeWidth="0.5"/>
-                <path d="M13.9991 14C12.3428 14 11 15.3401 11 16.9909C11 18.787 13.9991 23 13.9991 23C13.9991 23 17 18.7415 17 16.9909C17 15.3401 15.6572 14 13.9991 14ZM13.9991 17.7735C13.3796 17.7735 12.8767 17.2705 12.8767 16.653C12.8767 16.0356 13.3796 15.5325 13.9991 15.5325C14.6204 15.5325 15.1233 16.0356 15.1233 16.653C15.1233 17.2705 14.6204 17.7735 13.9991 17.7735Z" fill="white" stroke={color} strokeWidth="0.5" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round"/>
+                <path d="M13.9991 14C12.3428 14 11 15.3401 11 16.9909C11 18.787 13.9991 23 13.9991 23C13.9991 23 17 18.7415 17 16.9909C17 15.3401 15.6572 14 13.9991 14ZM13.9991 17.7735C13.3796 17.7735 12.8767 17.2705 12.8767 16.653C12.8767 16.0356 13.3796 15.5325 13.9991 15.5325C14.6204 15.5325 15.1233 16.0356 15.1233 16.653C15.1233 17.2705 14.6204 17.7735 13.9991 17.7735Z" fill="white" stroke="#0E0E0E" strokeWidth="0.5" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round"/>
                 <circle cx="14" cy="16.6499" r="1" fill="#0E0E0E"/>
             </svg>
         );

--- a/Frontend/src/components/ViewEventsCards/EventCardElement.module.scss
+++ b/Frontend/src/components/ViewEventsCards/EventCardElement.module.scss
@@ -2,8 +2,8 @@
 @import 'src/style/fonts';
 
 .icon {
-    height: 32px;
-    width: 32px;
+    height: 28px;
+    width: 28px;
     margin-right: 10px;
     @media #{$desktop} {
         margin-right: 3px;

--- a/Frontend/src/components/ViewEventsCards/EventCardElement.module.scss
+++ b/Frontend/src/components/ViewEventsCards/EventCardElement.module.scss
@@ -27,7 +27,7 @@
     color: black;
   }
   &:hover .locationIcon path {
-    fill: black;
+    stroke: black;
   }
 
   &:hover .stateIcon path {

--- a/Frontend/src/components/ViewEventsCards/EventCardElement.module.scss
+++ b/Frontend/src/components/ViewEventsCards/EventCardElement.module.scss
@@ -202,36 +202,22 @@
   color: var(--havKontrast);
 }
 
-.location {
+.iconContainer {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
   text-align: center;
+  margin-bottom: 10px;
 }
 
 .iconText {
+  flex: 1;
   margin-right: 10px;
   font-size: 16px;
   margin-left: 5px;
   text-align: left;
-}
-
-.locationIcon {
-  min-width: 20px;
-  min-height: 20px;
-}
-
-.external {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  padding-top: 10px;
-  text-align: center;
-}
-
-.externalIcon {
-  width: 20px;
-  height: 20px;
+  line-height: 22px;
+  word-break: break-word;
 }
 
 .cardFooter {

--- a/Frontend/src/components/ViewEventsCards/EventCardElement.tsx
+++ b/Frontend/src/components/ViewEventsCards/EventCardElement.tsx
@@ -132,7 +132,7 @@ export const EventCardElement = ({ eventId, event }: IProps) => {
       )}
       <div className={style.location}>
         <div className={style.locationIcon}>
-          <LocationIcon color="white" />
+          <LocationIcon color="white" className={style.icon} />
         </div>
         <div className={style.iconText}>{event.location}</div>
       </div>

--- a/Frontend/src/components/ViewEventsCards/EventCardElement.tsx
+++ b/Frontend/src/components/ViewEventsCards/EventCardElement.tsx
@@ -119,23 +119,25 @@ export const EventCardElement = ({ eventId, event }: IProps) => {
     <Link className={cardStyle} to={viewRoute}>
       <div className={style.smallFont}>{dateTimeText}</div>
       <div className={titleStyle}>{event.title}</div>
+
       {event.offices && (
-        <div className={style.location}>
+        <div className={style.iconContainer}>
           <div className={style.officeIcon}>
             <OfficeIcon color="white" className={style.icon} />
           </div>
-
           <div className={style.iconText}>
             {(pickedOfficeToOfficeList(event.offices) || []).join(', ')}
           </div>
         </div>
       )}
-      <div className={style.location}>
+
+      <div className={style.iconContainer}>
         <div className={style.locationIcon}>
           <LocationIcon color="white" className={style.icon} />
         </div>
         <div className={style.iconText}>{event.location}</div>
       </div>
+
       {event.isHidden && (
         <p className={style.hidden}>
           Psst! Arrangementet er skjult for andre{' '}
@@ -144,14 +146,16 @@ export const EventCardElement = ({ eventId, event }: IProps) => {
           </span>
         </p>
       )}
+
       {event.isExternal && (
-        <div className={style.external}>
+        <div className={style.iconContainer}>
           <div className={style.externalIcon}>
-            <ExternalIcon color="white" />
+            <ExternalIcon color="white" className={style.icon} />
           </div>
-          <div className={style.iconText}> Eksternt arrangement </div>
+          <div className={style.iconText}>Eksternt arrangement</div>
         </div>
       )}
+
       <div className={style.cardFooter}>
         <ParticipationState
           eventId={eventId}


### PR DESCRIPTION
Airtable: https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/recChtBMwlWVoSG4R?blocks=hide

- Endret så location-ikonet ikke er fylt
- Nytt ikon for office
- Gjør alle ikonene litt mindre, og får mer felles stil og spacing
- Noen småfiks på ikon-teksten (line-height, flex, word-break)

**Gammel:**
![bilde](https://github.com/bekk/bekk-arrangement-svc/assets/5686884/600f1ee5-7ae9-4104-b98b-10a019888cd0)

**Ny:**
![bilde](https://github.com/bekk/bekk-arrangement-svc/assets/5686884/3acdff12-a29b-47cb-91b7-8ec865de6e59)