### PR TITLE
Kopier epost til utklippstavle med semikolon-separator - preview

### DIFF
--- a/Frontend/src/components/ViewEvent/ViewParticipants.tsx
+++ b/Frontend/src/components/ViewEvent/ViewParticipants.tsx
@@ -122,7 +122,7 @@ const ParticipantTableDesktop = (props: {
   };
   const copyEmails = async () => {
     await navigator.clipboard.writeText(
-      props.participants.map((p) => stringifyEmail(p.email)).join(', ')
+      props.participants.map((p) => stringifyEmail(p.email)).join('; ')
     );
     setWasCopied(true);
     setTimeout(() => {


### PR DESCRIPTION
Airtable: https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/recOaz59zCo4wu9fT?blocks=hide

Separerer epostene med semikolon istedenfor komma, slik at Outlook greier å skille mellom epostadressene.