### PR TITLE
Deltaker kan se sine spørsmål og svar inne i arrangementet - preview

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -717,7 +717,7 @@ let getParticipantsForEvent (eventId: Guid) =
 let createCsvString (event: Models.Event) (questions: ParticipantQuestion list) (participants: ParticipationsAndWaitlist) =
     let createParticipant (builder: System.Text.StringBuilder) (participantAndAnswers: ParticipantAndAnswers) =
         let participant = participantAndAnswers.Participant
-        let questionAndAnswers = participantAndAnswers.QuestionAndAnswer
+        let questionAndAnswers = participantAndAnswers.QuestionAndAnswers
         let answers =
             questionAndAnswers
             |> List.map (fun a -> $"\"{a.Answer}\"")
@@ -862,7 +862,7 @@ let deleteParticipantFromEvent (eventId: Guid) (email: string) =
                 let deletedParticipantAnswers =
                     participants
                     |> Seq.find (fun pa -> pa.Participant.Email = email)
-                    |> fun p -> p.QuestionAndAnswer
+                    |> fun p -> p.QuestionAndAnswers
                 sendParticipantCancelMails eventAndQuestions.Event deletedParticipant deletedParticipantAnswers personWhoGotIt context
                 return ()
             }

--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -185,11 +185,11 @@ let registerParticipation (eventId: Guid, email): HttpHandler =
                     |> TaskResult.mapError InternalError
                 
                 // Sende epost
+                let questionAndAnswers = createQuestionAndAnswer eventQuestions answers
                 let isWaitlisted = eventAndQuestions.Event.HasWaitingList && isParticipating = false
                 let email =
                     let viewUrl = createViewUrl writeModel.ViewUrlTemplate eventAndQuestions.Event
                     let cancelUrl = createCancelUrl writeModel.CancelUrlTemplate participant
-                    let questionAndAnswer = createQuestionAndAnswer eventQuestions answers
                         
                     createNewParticipantMail
                         viewUrl
@@ -198,11 +198,11 @@ let registerParticipation (eventId: Guid, email): HttpHandler =
                         isWaitlisted
                         config.noReplyEmail
                         participant
-                        questionAndAnswer
+                        questionAndAnswers
                 
                 sendMail email context
 
-                return Participant.encodeWithCancelInfo participant answers
+                return Participant.encodeWithCancelInfo participant questionAndAnswers
             }
         jsonResult result next context
 
@@ -717,9 +717,9 @@ let getParticipantsForEvent (eventId: Guid) =
 let createCsvString (event: Models.Event) (questions: ParticipantQuestion list) (participants: ParticipationsAndWaitlist) =
     let createParticipant (builder: System.Text.StringBuilder) (participantAndAnswers: ParticipantAndAnswers) =
         let participant = participantAndAnswers.Participant
-        let answers = participantAndAnswers.Answers
+        let questionAndAnswers = participantAndAnswers.QuestionAndAnswer
         let answers =
-            answers
+            questionAndAnswers
             |> List.map (fun a -> $"\"{a.Answer}\"")
             |> String.concat ","
         let employeeId =
@@ -862,8 +862,8 @@ let deleteParticipantFromEvent (eventId: Guid) (email: string) =
                 let deletedParticipantAnswers =
                     participants
                     |> Seq.find (fun pa -> pa.Participant.Email = email)
-                    |> fun p -> p.Answers
-                sendParticipantCancelMails eventAndQuestions.Event eventAndQuestions.Questions deletedParticipant deletedParticipantAnswers personWhoGotIt context
+                    |> fun p -> p.QuestionAndAnswer
+                sendParticipantCancelMails eventAndQuestions.Event deletedParticipant deletedParticipantAnswers personWhoGotIt context
                 return ()
             }
         jsonResult result next context

--- a/Arrangement-Svc/Models/Models.fs
+++ b/Arrangement-Svc/Models/Models.fs
@@ -412,12 +412,12 @@ module Participant =
             "cancellationToken", Encode.guid participantAndAnswers.Participant.CancellationToken
         ]
 
-    let encodeToLocalStorage (participant: ParticipantAndAnswers) =
+    let encodeToLocalStorage (participantAndAnswers: ParticipantAndAnswers) =
         Encode.object [
-            "eventId", Encode.guid participant.Participant.EventId
-            "email", Encode.string participant.Participant.Email
-            "cancellationToken", Encode.guid participant.Participant.CancellationToken
-            "questionAndAnswers", participant.QuestionAndAnswers
+            "eventId", Encode.guid participantAndAnswers.Participant.EventId
+            "email", Encode.string participantAndAnswers.Participant.Email
+            "cancellationToken", Encode.guid participantAndAnswers.Participant.CancellationToken
+            "questionAndAnswers", participantAndAnswers.QuestionAndAnswers
                        |> List.map encodeQuestionAndAnswer
                        |> Encode.list
         ]

--- a/Arrangement-Svc/Models/Models.fs
+++ b/Arrangement-Svc/Models/Models.fs
@@ -396,14 +396,18 @@ module Participant =
             "cancellationToken", Encode.guid participantAndAnswers.Participant.CancellationToken
         ]
 
-    let encodeToLocalStorage (participant: Participant) =
+    let encodeToLocalStorage (participant: ParticipantAndAnswers) =
         Encode.object [
-            "eventId", Encode.guid participant.EventId
-            "email", Encode.string participant.Email
-            "cancellationToken", Encode.guid participant.CancellationToken
+            "eventId", Encode.guid participant.Participant.EventId
+            "email", Encode.string participant.Participant.Email
+            "cancellationToken", Encode.guid participant.Participant.CancellationToken
+            "answers", participant.Answers
+                       |> List.map (fun answer -> answer.Answer)
+                       |> List.map Encode.string
+                       |> Encode.list
         ]
 
-    let encodeWithLocalStorage (eventAndQuestions: EventAndQuestions list) (participations: Participant list) =
+    let encodeWithLocalStorage (eventAndQuestions: EventAndQuestions list) (participations: ParticipantAndAnswers list) =
         Encode.object [
            "editableEvents", eventAndQuestions |> List.map Event.encoderWithEditInfo |> Encode.list
            "participations", participations |> List.map encodeToLocalStorage |> Encode.list

--- a/Arrangement-Svc/Models/Models.fs
+++ b/Arrangement-Svc/Models/Models.fs
@@ -369,7 +369,7 @@ type QuestionAndAnswer = {
 }
 type ParticipantAndAnswers = {
     Participant: Participant
-    QuestionAndAnswer: QuestionAndAnswer list
+    QuestionAndAnswers: QuestionAndAnswer list
 }
 type ParticipationsAndWaitlist =
     { Attendees: ParticipantAndAnswers list
@@ -391,7 +391,7 @@ module Participant =
     ]
     let encodeParticipantAndAnswers (participantAndAnswers: ParticipantAndAnswers) =
         let participant = participantAndAnswers.Participant
-        let questionAndAnswers = participantAndAnswers.QuestionAndAnswer
+        let questionAndAnswers = participantAndAnswers.QuestionAndAnswers
         Encode.object [
             "name", Encode.string participant.Name
             "email", Encode.string participant.Email
@@ -406,7 +406,7 @@ module Participant =
         ]
 
     let encodeWithCancelInfo (participant: Participant) (questionAndAnswers: QuestionAndAnswer list) =
-        let participantAndAnswers = {Participant = participant; QuestionAndAnswer = questionAndAnswers }
+        let participantAndAnswers = {Participant = participant; QuestionAndAnswers = questionAndAnswers }
         Encode.object [
             "participant", encodeParticipantAndAnswers participantAndAnswers
             "cancellationToken", Encode.guid participantAndAnswers.Participant.CancellationToken
@@ -417,7 +417,7 @@ module Participant =
             "eventId", Encode.guid participant.Participant.EventId
             "email", Encode.string participant.Participant.Email
             "cancellationToken", Encode.guid participant.Participant.CancellationToken
-            "questionAndAnswers", participant.QuestionAndAnswer
+            "questionAndAnswers", participant.QuestionAndAnswers
                        |> List.map encodeQuestionAndAnswer
                        |> Encode.list
         ]

--- a/Arrangement-Svc/Models/Models.fs
+++ b/Arrangement-Svc/Models/Models.fs
@@ -367,6 +367,16 @@ type ParticipantAndAnswers = {
     Answers: ParticipantAnswer list
 }
 
+type QuestionAndAnswer = {
+    QuestionId: int
+    Question: string
+    Answer: string
+}
+type ParticipantAndQuestionAndAnswers = {
+    Participant: Participant
+    QuestionAndAnswer: QuestionAndAnswer list
+}
+
 type ParticipationsAndWaitlist =
     { Attendees: ParticipantAndAnswers list
       WaitingList: ParticipantAndAnswers list
@@ -396,18 +406,18 @@ module Participant =
             "cancellationToken", Encode.guid participantAndAnswers.Participant.CancellationToken
         ]
 
-    let encodeToLocalStorage (participant: ParticipantAndAnswers) =
+    let encodeToLocalStorage (participant: ParticipantAndQuestionAndAnswers) =
         Encode.object [
             "eventId", Encode.guid participant.Participant.EventId
             "email", Encode.string participant.Participant.Email
             "cancellationToken", Encode.guid participant.Participant.CancellationToken
-            "answers", participant.Answers
-                       |> List.map (fun answer -> answer.Answer)
+            "questionAndAnswers", participant.QuestionAndAnswer
+                       |> List.map (fun qa -> $"{qa.Question}: {qa.Answer}")
                        |> List.map Encode.string
                        |> Encode.list
         ]
 
-    let encodeWithLocalStorage (eventAndQuestions: EventAndQuestions list) (participations: ParticipantAndAnswers list) =
+    let encodeWithLocalStorage (eventAndQuestions: EventAndQuestions list) (participations: ParticipantAndQuestionAndAnswers list) =
         Encode.object [
            "editableEvents", eventAndQuestions |> List.map Event.encoderWithEditInfo |> Encode.list
            "participations", participations |> List.map encodeToLocalStorage |> Encode.list

--- a/Arrangement-Svc/Queries/Queries.fs
+++ b/Arrangement-Svc/Queries/Queries.fs
@@ -453,7 +453,7 @@ let getParticipationsById (id: int) (db: DatabaseContext) =
             let result: Models.ParticipantAndAnswers seq =
                 participants
                 |> Seq.fromDict
-                |> Seq.map (fun (x, y) -> { Participant = x; QuestionAndAnswer = y })
+                |> Seq.map (fun (x, y) -> { Participant = x; QuestionAndAnswers = y })
 
             return Ok result
         with
@@ -1053,7 +1053,7 @@ let getParticipantsAndAnswersForEvent (eventId: Guid) (db: DatabaseContext) =
             let result: Models.ParticipantAndAnswers seq =
                 participants
                 |> Seq.fromDict
-                |> Seq.map (fun (x, y) -> { Participant = x; QuestionAndAnswer = y })
+                |> Seq.map (fun (x, y) -> { Participant = x; QuestionAndAnswers = y })
 
             return Ok result
         with
@@ -1105,7 +1105,7 @@ let getParticipationsForParticipant email (db: DatabaseContext) =
             let result: Models.ParticipantAndAnswers seq =
                 participants
                 |> Seq.fromDict
-                |> Seq.map (fun (x, y) -> { Participant = x; QuestionAndAnswer = y })
+                |> Seq.map (fun (x, y) -> { Participant = x; QuestionAndAnswers = y })
 
             return Ok result
         with

--- a/Frontend/src/components/CancelParticipant/CancelParticipant.tsx
+++ b/Frontend/src/components/CancelParticipant/CancelParticipant.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { deleteParticipant } from 'src/api/arrangementSvc';
 import { Page } from '../Page/Page';
 import { Button } from '../Common/Button/Button';
@@ -39,23 +39,6 @@ export const CancelParticipant = () => {
     ? remoteWaitinglistSpot.data !== 'ikke-påmeldt' &&
       remoteWaitinglistSpot.data >= 1
     : undefined;
-
-  const { saveParticipation } = useSavedParticipations();
-  useEffect(() => {
-    if (cancellationToken && !wasDeleted) {
-      saveParticipation({
-        eventId,
-        email: participantEmail,
-        cancellationToken,
-      });
-    }
-  }, [
-    eventId,
-    participantEmail,
-    cancellationToken,
-    saveParticipation,
-    wasDeleted,
-  ]);
 
   const cancelParticipant = catchAndNotify(async () => {
     if (eventId && participantEmail) {

--- a/Frontend/src/components/ViewEvent/AddParticipant.tsx
+++ b/Frontend/src/components/ViewEvent/AddParticipant.tsx
@@ -75,13 +75,11 @@ export const AddParticipant = ({
         throw e;
       });
 
-
-
       saveParticipation({
           eventId,
           email: response.participant.email || '',
           cancellationToken: response.cancellationToken,
-          questionAndAnswers: response.participant.questionAndAnswers }); //TODO HN
+          questionAndAnswers: response.participant.questionAndAnswers });
 
       history.push(
         confirmParticipantRoute({

--- a/Frontend/src/components/ViewEvent/AddParticipant.tsx
+++ b/Frontend/src/components/ViewEvent/AddParticipant.tsx
@@ -66,10 +66,7 @@ export const AddParticipant = ({
     if (validParticipant) {
       setWaitingOnParticipation(true);
 
-      const {
-        participant: { email = '' },
-        cancellationToken,
-      } = await postParticipant(
+      const response = await postParticipant(
         event,
         eventId,
         validParticipant
@@ -78,12 +75,18 @@ export const AddParticipant = ({
         throw e;
       });
 
-      saveParticipation({ eventId, email, cancellationToken });
+
+
+      saveParticipation({
+          eventId,
+          email: response.participant.email || '',
+          cancellationToken: response.cancellationToken,
+          questionAndAnswers: response.participant.questionAndAnswers }); //TODO HN
 
       history.push(
         confirmParticipantRoute({
           eventId,
-          email: encodeURIComponent(email),
+          email: encodeURIComponent(response.participant.email || ''),
         })
       );
     }

--- a/Frontend/src/components/ViewEvent/ViewEventContainer.module.scss
+++ b/Frontend/src/components/ViewEvent/ViewEventContainer.module.scss
@@ -99,3 +99,12 @@
 .content {
   max-width: 800px;
 }
+
+.question {
+  font-family: $fontMedium;
+}
+
+.answer {
+  font-family: $fontLight;
+  margin-bottom: 10px;
+}

--- a/Frontend/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/Frontend/src/components/ViewEvent/ViewEventContainer.tsx
@@ -232,6 +232,13 @@ export const ViewEventContainer = ({ eventId }: IProps) => {
                 En bekreftelse er sendt på e-post til{' '}
                 {participationsForThisEvent[0].email}
               </p>
+              {participationsForThisEvent[0].questionAndAnswers.map(
+                  (qa, i) =>
+                      <div key={`${qa}:${i}`}>
+                        <div className={style.question}>{qa.question}</div>
+                        <div className={style.answer}>{qa.answer}</div>
+                      </div>
+              )}
               <h2 className={style.subHeader}>Kan du ikke likevel?</h2>
               <Button
                 onClick={() =>

--- a/Frontend/src/hooks/saved-tokens.ts
+++ b/Frontend/src/hooks/saved-tokens.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { getEventsAndParticipationsForEmployee } from 'src/api/arrangementSvc';
 import { getEmployeeId, isAuthenticated } from 'src/auth';
 import { useLocalStorage } from 'src/hooks/localStorage';
+import {IQuestionAndAnswer} from "../types/participant";
 
 export type EditEventToken = {
   eventId: string;
@@ -58,6 +59,7 @@ export type Participation = {
   eventId: string;
   email: string;
   cancellationToken: string;
+  questionAndAnswers: IQuestionAndAnswer[];
 };
 const isParticipationAndHasCancellationToken = (x: any): x is Participation =>
   'eventId' in x &&
@@ -100,6 +102,7 @@ export const useSavedParticipations = () => {
   return {
     savedParticipations: readValidatedStorage(),
     saveParticipation: (participant: Participation) => {
+      console.log('saveParticipation', participant);
       setStorage(updateStorage(participant));
     },
     removeSavedParticipant: (participant: { eventId: string; email: string }) =>

--- a/Frontend/src/types/participant.ts
+++ b/Frontend/src/types/participant.ts
@@ -21,7 +21,12 @@ export interface IParticipantViewModel {
   department: string;
   eventId: string;
   registrationTime: number;
-  participantAnswers: string[];
+  questionAndAnswers: IQuestionAndAnswer[];
+}
+
+export interface IQuestionAndAnswer {
+  question: string;
+  answer: string;
 }
 
 export interface IParticipantsWithWaitingList {
@@ -71,13 +76,13 @@ export const parseParticipantViewModel = (
     ? parseEmailViewModel(participantView.email)
     : { email: '' };
   const name = parseName(participantView.name);
-  const answers = parseAnswers(participantView.participantAnswers);
+  const answers = parseAnswers(participantView.questionAndAnswers.map(qa => qa.answer));
 
   const participant = {
     ...participantView,
     email,
     name,
-    answers,
+    participantAnswers: answers,
   };
 
   assertIsValid(participant);

--- a/Tests/Utils/Models.fs
+++ b/Tests/Utils/Models.fs
@@ -37,21 +37,30 @@ type InnerEvent = { Id: string
 type CreatedEvent =
     { EditToken: string
       Event: InnerEvent }
-
+    
 type InnerParticipant =
     { Name: string
       Email: string
       EmployeeId: int option
-      ParticipantAnswers: string list }
-
+      QuestionAndAnswers: QuestionAndAnswer list }
+    
 type CreatedParticipant =
     { Participant: InnerParticipant
       CancellationToken: string }
 
-type ParticipantAndAnswers = { Name: string }
+type ParticipantAndAnswers =
+    { Name: string
+      QuestionAndAnswers: QuestionAndAnswer list }
 
+let questionAndAnswerDecoder: Decoder<QuestionAndAnswer> =
+    Decode.object (fun get ->
+        { Question = get.Required.Field "question" Decode.string
+          Answer = get.Required.Field "answer" Decode.string })
+    
 let participantAndAnswerDecoder: Decoder<ParticipantAndAnswers> =
-    Decode.object (fun get -> { Name = get.Required.Field "name" Decode.string })
+    Decode.object (fun get ->
+        { Name = get.Required.Field "name" Decode.string
+          QuestionAndAnswers = get.Required.Field "questionAndAnswers" (Decode.list questionAndAnswerDecoder) })
 
 type ParticipationsAndWaitlist =
     { Attendees: ParticipantAndAnswers list
@@ -82,7 +91,7 @@ let innerParticipantDecoder: Decoder<InnerParticipant> =
         { Name = get.Required.Field "name" Decode.string
           Email = get.Required.Field "email" Decode.string
           EmployeeId = get.Optional.Field "employeeId" Decode.int
-          ParticipantAnswers = get.Required.Field "participantAnswers" (Decode.list Decode.string) })
+          QuestionAndAnswers = get.Required.Field "questionAndAnswers" (Decode.list questionAndAnswerDecoder) })
 
 let createdParticipantDecoder: Decoder<CreatedParticipant> =
     Decode.object (fun get ->


### PR DESCRIPTION
**Airtable**: https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/rec9PFel99hvOVICN?blocks=hide

Viser nå spørsmål og svar inne på arrangementet:

![image](https://github.com/bekk/bekk-arrangement-svc/assets/6769643/7eae51d4-0c45-442f-a6da-cd979d1545f0)

Endringer:

- Utvidet backend til å gi tilbake både spørsmål og svar når man henter ut deltakere
- Endret modellene i frontend til å matche dette, samt liste ut spørsmålene og svarene
- Endringene påvirker [forrige PR med å vise spørsmål og svar i mailen](https://github.com/bekk/bekk-arrangement-svc/pull/159), da jeg toucher innom en del felles modeller i backend. 

Foreløpig ikke endret noe på utlisting av spørsmål og svar under deltakerlista nederst. Altså denne, som har en mer naiv utlisting av spørsmål og svar (lister bare ut spørsmål og svar på samme indeks i to ulike lister):

![image](https://github.com/bekk/bekk-arrangement-svc/assets/6769643/e4aa2916-71f4-4c53-87c2-434e81565757)
