### PR TITLE
Properly split newlines - preview

### DIFF
--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -245,7 +245,7 @@ let private createCancelledEventMail
     (participant: Participant)
     =
     { Subject = $"Avlyst: {event.Title}"
-      Message = message.Replace("\\n", "<br>")[1..(message.Length-2)]
+      Message = message
       To = participant.Email
       CalendarInvite =
           createCalendarAttachment
@@ -297,6 +297,9 @@ let sendCancellationMailToParticipants
     event
     ctx
     =
+    let messageToParticipants =
+        messageToParticipants.Replace("\n", "<br>")[1..(messageToParticipants.Length-2)]
+
     let sendMailToParticipant participant =
         sendMail
             (createCancelledEventMail messageToParticipants event

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -245,7 +245,7 @@ let private createCancelledEventMail
     (participant: Participant)
     =
     { Subject = $"Avlyst: {event.Title}"
-      Message = message.Replace("\\n", "<br>").Replace("\"", "")
+      Message = message.Replace("\\n", "<br>")[1..(message.Length-2)]
       To = participant.Email
       CalendarInvite =
           createCalendarAttachment

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -134,15 +134,15 @@ let private getQuestionsAndAnswers title (questionAndAnswer: QuestionAndAnswer l
             ""
         else ""
     ]
-   
+
 let private inviteMessage viewUrl cancelUrl (event: Models.Event) (questionAndAnswers: QuestionAndAnswer list) =
     [ "Hei! 😄"
       ""
       $"Du er nå påmeldt <a href=\"{viewUrl}\">{event.Title}</a>."
       $"Vi gleder oss til å se deg på {event.Location} den {DateTimeCustom.toReadableString (DateTimeCustom.toCustomDateTime event.StartDate event.StartTime)} 🎉"
-      
+
       yield! getQuestionsAndAnswers "Dine svar" questionAndAnswers
-      
+
       if event.MaxParticipants.IsSome then
         "Siden det er begrenset med plasser, setter vi pris på om du melder deg av hvis du ikke lenger<br>kan delta. Da blir det plass til andre på ventelisten 😊"
       else "Gjerne meld deg av dersom du ikke lenger har mulighet til å delta."
@@ -159,9 +159,9 @@ let private waitlistedMessage viewUrl cancelUrl (event: Models.Event) (questionA
       ""
       $"Du er nå på venteliste for <a href=\"{viewUrl}\">{event.Title}</a> på {event.Location} den {DateTimeCustom.toReadableString (DateTimeCustom.toCustomDateTime event.StartDate event.StartTime)}."
       "Du vil få beskjed på e-post om du rykker opp fra ventelisten."
-      
+
       yield! getQuestionsAndAnswers "Dine svar" questionAndAnswers
-      
+
       "Siden det er begrenset med plasser, setter vi pris på om du melder deg av hvis du ikke lenger"
       "kan delta. Da blir det plass til andre på ventelisten 😊"
       $"Du kan melde deg av <a href=\"{cancelUrl}\">via denne lenken</a>."
@@ -202,11 +202,11 @@ let private createCancelledParticipationMailToOrganizer
     =
         let message =
             [ $"{participant.Name} har meldt seg av {event.Title}"
-              
+
               yield! getQuestionsAndAnswers "Deltaker har svart" participantAnswers
             ]
             |> String.concat "<br>"
-        
+
         { Subject = "Avmelding"
           Message = message
           To = event.OrganizerEmail
@@ -245,7 +245,7 @@ let private createCancelledEventMail
     (participant: Participant)
     =
     { Subject = $"Avlyst: {event.Title}"
-      Message = message.Replace("\n", "<br>")
+      Message = message.Replace("\\n", "<br>")
       To = participant.Email
       CalendarInvite =
           createCalendarAttachment
@@ -291,12 +291,15 @@ let private createCancellationConfirmationToOrganizer
     }
 
 let sendCancellationMailToParticipants
-    messageToParticipants
+    (messageToParticipants: string)
     noReplyMail
     participants
     event
     ctx
     =
+
+    let messageToParticipants = messageToParticipants.Replace("\\n", "<br>")
+
     let sendMailToParticipant participant =
         sendMail
             (createCancelledEventMail messageToParticipants event

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -298,7 +298,7 @@ let sendCancellationMailToParticipants
     ctx
     =
     let messageToParticipants =
-        messageToParticipants.Replace("\n", "<br>")[1..(messageToParticipants.Length-2)]
+        messageToParticipants.Replace("\\n", "<br>")[1..(messageToParticipants.Length-2)]
 
     let sendMailToParticipant participant =
         sendMail

--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -245,7 +245,7 @@ let private createCancelledEventMail
     (participant: Participant)
     =
     { Subject = $"Avlyst: {event.Title}"
-      Message = message.Replace("\\n", "<br>")
+      Message = message.Replace("\\n", "<br>").Replace("\"", "")
       To = participant.Email
       CalendarInvite =
           createCalendarAttachment
@@ -297,9 +297,6 @@ let sendCancellationMailToParticipants
     event
     ctx
     =
-
-    let messageToParticipants = messageToParticipants.Replace("\\n", "<br>")
-
     let sendMailToParticipant participant =
         sendMail
             (createCancelledEventMail messageToParticipants event


### PR DESCRIPTION
Det har alltid vært en bug med hvordan avlys-eposter genereres og sendes ut.

Formatering ble gjort på feil sted, og det manglet en escape.
Legger også til at den fjerner den første og siste karakteren i strengen, som av en eller annen grunn alltid var ekstra ".

For å teste dette, så kan du opprette et arrangement og deretter avlyse det.
Skriv en litt lengre tekst med linjeskift og sjekk eposten du får.