### PR TITLE
Styling office events - preview

### DIFF
--- a/Frontend/src/components/EditEvent/EditEvent/EditEvent.module.scss
+++ b/Frontend/src/components/EditEvent/EditEvent/EditEvent.module.scss
@@ -157,6 +157,14 @@
   margin-bottom: 10px;
 }
 
+.informationContent {
+  margin-left: 20px;
+  color: var(--svart);
+  font-family: $fontRegular;
+  font-weight: 400;
+  font-size: 14px;
+}
+
 .listStyle {
   & > li {
     color: var(--svart);

--- a/Frontend/src/components/EditEvent/EditEvent/EditEvent.tsx
+++ b/Frontend/src/components/EditEvent/EditEvent/EditEvent.tsx
@@ -554,10 +554,13 @@ export const EditEvent = ({ eventResult: event, updateEvent }: IProps) => {
         </Button>
         {event.participantQuestions.length > 0 && (
           <InfoBox title="Formateringshjelp">
-            <p>Spørsmål:</p>
-            <p>
-              &#47;&#47; Alternativer: alternativ 1; alternativ 2; alternativ 3
-            </p>
+            <div className={style.informationContent}>
+              <p>Spørsmål:</p>
+              <p>
+                &#47;&#47; Alternativer: alternativ 1; alternativ 2; alternativ
+                3
+              </p>
+            </div>
           </InfoBox>
         )}
       </div>

--- a/Frontend/src/components/OfficeEvents/OfficeEvents.module.scss
+++ b/Frontend/src/components/OfficeEvents/OfficeEvents.module.scss
@@ -23,7 +23,7 @@
   border-collapse: collapse;
   margin: 0;
   padding: 0;
-  width: 80%;
+  width: 90%;
   table-layout: fixed;
 }
 
@@ -59,8 +59,8 @@
 }
 .table td {
   padding: 0.625em;
-  width: 200px;
-  height: 200px;
+  width: 33.33%;
+  max-width: 50%;
   border: 1px solid var(--svart50);
   vertical-align: top;
   text-align: left;
@@ -68,6 +68,10 @@
   font-weight: 400;
   font-size: 18px;
   line-height: 23px;
+}
+
+.tableContent  {
+  aspect-ratio: 1 / 1;
 }
 
 @media screen and (max-width: 600px) {
@@ -140,6 +144,15 @@
   font-weight: 400;
   font-size: 14px;
   line-height: 18px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  &:hover {
+    font-weight: 800;
+    &::before {
+      width: 4px;
+    }
+  }
   &::before {
     display: inline-block;
     content: '';
@@ -148,6 +161,12 @@
     margin-right: 0.5em;
     background-color: white;
     vertical-align: bottom;
+  }
+}
+
+.eventOverskyetKontrast {
+  &::before {
+    background-color: var(--overskyetKontrast);
   }
 }
 

--- a/Frontend/src/components/OfficeEvents/OfficeEvents.module.scss
+++ b/Frontend/src/components/OfficeEvents/OfficeEvents.module.scss
@@ -50,6 +50,14 @@
   padding: 0.35em;
 }
 
+.table tr td:first-child::before {
+  color: var(--svart70);
+  font-size: 12px;
+  left: 3%;
+  position: absolute;
+  content: attr(data-label);
+}
+
 .table th {
   padding: 0.625em;
   font-family: $serifFontRegular;

--- a/Frontend/src/components/OfficeEvents/OfficeEvents.module.scss
+++ b/Frontend/src/components/OfficeEvents/OfficeEvents.module.scss
@@ -51,11 +51,13 @@
 }
 
 .table tr td:first-child::before {
-  color: var(--svart70);
-  font-size: 12px;
-  left: 3%;
-  position: absolute;
-  content: attr(data-label);
+  @media screen and (min-width: 600px) {
+    color: var(--svart70);
+    font-size: 12px;
+    left: 3%;
+    position: absolute;
+    content: attr(data-label);
+  }
 }
 
 .table th {
@@ -101,6 +103,8 @@
   .table tr {
     display: block;
     margin-bottom: 0.625em;
+    margin-left: 26px;
+    width: 680px;
   }
 
   .table td {
@@ -108,10 +112,15 @@
     font-size: 0.8em;
     text-align: right;
     width: 100%;
+    height: 100px;
   }
 
   .table tr::before {
     content: attr(data-label);
+  }
+
+  .tableContent  {
+    aspect-ratio: unset;
   }
 }
 

--- a/Frontend/src/components/OfficeEvents/OfficeEvents.tsx
+++ b/Frontend/src/components/OfficeEvents/OfficeEvents.tsx
@@ -25,7 +25,7 @@ import { officeEventRoute, officeEventsMonthKey } from 'src/routing';
 import { useParam } from 'src/utils/browser-state';
 import { useEffectOnce } from 'src/hooks/utils';
 import { Spinner } from 'src/components/Common/Spinner/spinner';
-import { OfficeEvent } from '../../types/OfficeEvent';
+import { OfficeEvent } from 'src/types/OfficeEvent';
 
 export const OfficeEvents = () => {
   const urlDate = useParam(officeEventsMonthKey);
@@ -157,7 +157,7 @@ const WeekDayCards = ({
         const borderStyle = classnames({
           [style.notCurrentMonthDay]: isPreviousDay(day),
         });
-        const dateStyle = classnames({
+        const dateStyle = classnames(style.tableContent, {
           [style.notCurrentMonthDate]: isPreviousDay(day),
           [style.currentDate]: isToday(day) || isNextMonth(day),
         });
@@ -170,6 +170,9 @@ const WeekDayCards = ({
               <div className={dateHighlighter}>{day.getDate()}</div>
               {events.map((event) => (
                 <Event
+                  isPreviousDayOrNextMonth={
+                    isPreviousDay(day) || isNextMonth(day)
+                  }
                   key={`${event.title}:${event.contactPerson}`}
                   event={event}
                   setSelectedEvent={setSelectedEvent}
@@ -184,13 +187,17 @@ const WeekDayCards = ({
 };
 
 const Event = ({
+  isPreviousDayOrNextMonth,
   event,
   setSelectedEvent,
 }: {
+  isPreviousDayOrNextMonth: boolean;
   event: OfficeEvent;
   setSelectedEvent: (x: OfficeEvent) => void;
 }) => {
+  // Tanken bak at disse alltid er false er å på sikt kunne differensiere mellom forskjellige typer events og fargelegge dem forskjellig.
   const eventStyle = classnames(style.event, {
+    [style.eventOverskyetKontrast]: isPreviousDayOrNextMonth,
     [style.eventSolkontrast]: false,
     [style.eventHavkontrast]: false,
     [style.eventKveldkontrast]: false,

--- a/Frontend/src/components/OfficeEvents/OfficeEvents.tsx
+++ b/Frontend/src/components/OfficeEvents/OfficeEvents.tsx
@@ -148,10 +148,9 @@ const WeekDayCards = ({
   const isToday = (day: Date) =>
     day.toDateString() === currentDate.toDateString();
   const isNextMonth = (day: Date) => day.getMonth() > currentDate.getMonth();
+  const weekNr = getWeek(daysAndEvents[0].day);
   return (
-    <tr
-      key={getWeek(daysAndEvents[0].day)}
-      data-label={getWeek(daysAndEvents[0].day)}>
+    <tr key={weekNr} data-label={weekNr}>
       {daysAndEvents.map((dayAndEvents) => {
         const { day, events } = dayAndEvents;
         const borderStyle = classnames({
@@ -165,7 +164,7 @@ const WeekDayCards = ({
           [style.todayHighlighter]: isToday(day),
         });
         return (
-          <td className={borderStyle} key={day.getDate()}>
+          <td data-label={weekNr} className={borderStyle} key={day.getDate()}>
             <div className={dateStyle}>
               <div className={dateHighlighter}>{day.getDate()}</div>
               {events.map((event) => (


### PR DESCRIPTION
Styler office-events.

- Gjør rutene i kalenderen mer kvadratiske.
- Legger til ukenummer.
- Forkorter navn med ellipser dersom navnet er for langt.
- Hover effekt på event

> [!IMPORTANT]  
> Det er ikke mange eventer i dev å teste med, Men i 2017-02-03 er det noen.