### PR TITLE
Style infobox text and padding consistently

### DIFF
--- a/Frontend/src/components/Common/InfoBox/InfoBox.module.scss
+++ b/Frontend/src/components/Common/InfoBox/InfoBox.module.scss
@@ -40,7 +40,9 @@
   transition-duration: 200ms;
   transition-timing-function: ease-in-out;
   transition-property: max-height;
-  color: black;
+  color: var(--svart);
+  font-size: 14px;
+  padding-left: 20px;
 }
 
 .childrenOpen {

--- a/Frontend/src/components/EditEvent/EditEvent/EditEvent.module.scss
+++ b/Frontend/src/components/EditEvent/EditEvent/EditEvent.module.scss
@@ -158,12 +158,7 @@
 }
 
 .listStyle {
-  & > li {
-    color: var(--svart);
-    font-family: $fontRegular;
-    font-weight: 400;
-    font-size: 14px;
-  }
+  padding-left: 20px;
 }
 
 .office {


### PR DESCRIPTION
Gjør så font styling og padding stemmer mer overens i Formateringshjelp-boksene.

Før:
![image](https://github.com/bekk/bekk-arrangement-svc/assets/18345134/28b5c842-3236-4370-87d1-980d283a1ba0)


Etter:
![image](https://github.com/bekk/bekk-arrangement-svc/assets/18345134/9d57135e-2838-4249-9e94-3ec1cada2091)
