### PR TITLE
Fix paths for preview in edit/create event - preview

### DIFF
--- a/Frontend/src/components/CreateEvent/CreateEvent.tsx
+++ b/Frontend/src/components/CreateEvent/CreateEvent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IEditEvent, initialEditEvent } from 'src/types/event';
-import { eventsRoute } from 'src/routing';
+import { eventsRoute, previewNewEventRoute } from 'src/routing';
 import { useAuthentication } from 'src/auth';
 import { Page } from 'src/components/Page/Page';
 import { EventForm } from '../EventForm/EventForm';
@@ -35,7 +35,9 @@ export const CreateEvent = () => {
       <h1 className={style.header}>Opprett arrangement</h1>
       <EventForm eventResult={event} updateEvent={setEvent} />
       <div className={style.buttonContainer}>
-        <PreviewEventButton event={event}>Forhåndsvisning</PreviewEventButton>
+        <PreviewEventButton event={event} path={previewNewEventRoute}>
+          Forhåndsvisning
+        </PreviewEventButton>
         <BlockLink to={eventsRoute} onLightBackground>
           Avbryt
         </BlockLink>

--- a/Frontend/src/components/EditEvent/EditEvent.tsx
+++ b/Frontend/src/components/EditEvent/EditEvent.tsx
@@ -4,7 +4,12 @@ import { IEditEvent, toEditEvent } from 'src/types/event';
 import { deleteEvent } from 'src/api/arrangementSvc';
 import { useHistory } from 'react-router';
 import style from './EditEvent.module.scss';
-import { eventsRoute, editTokenKey, viewEventRoute } from 'src/routing';
+import {
+  eventsRoute,
+  editTokenKey,
+  viewEventRoute,
+  previewEventRoute,
+} from 'src/routing';
 import { hasLoaded } from 'src/remote-data';
 import { useQuery, useParam } from 'src/utils/browser-state';
 import { useNotification } from 'src/components/NotificationHandler/NotificationHandler';
@@ -101,7 +106,10 @@ export const EditEvent = () => {
               markert som avlyst.
             </p>
           </ButtonWithPromptModal>
-          <PreviewEventButton event={editEvent} className={style.button}>
+          <PreviewEventButton
+            event={editEvent}
+            path={previewEventRoute(eventId)}
+            className={style.button}>
             Forhåndsvis endringer
           </PreviewEventButton>
         </div>

--- a/Frontend/src/components/EventForm/PreviewEventButton.tsx
+++ b/Frontend/src/components/EventForm/PreviewEventButton.tsx
@@ -3,18 +3,23 @@ import { Button } from '../Common/Button/Button';
 import { IEditEvent, parseEditEvent } from 'src/types/event';
 import { isValid } from 'src/types/validation';
 import { useGotoEventPreview } from 'src/hooks/history';
-import { previewNewEventRoute } from 'src/routing';
 
 interface IProps {
   event: IEditEvent;
+  path: string;
   children: string;
   className?: string;
 }
 
-export const PreviewEventButton = ({ event, children, ...props }: IProps) => {
+export const PreviewEventButton = ({
+  event,
+  path,
+  children,
+  ...props
+}: IProps) => {
   const parsedEvent = parseEditEvent(event);
   const eventIsValid = isValid(parsedEvent);
-  const gotoPreview = useGotoEventPreview(previewNewEventRoute);
+  const gotoPreview = useGotoEventPreview(path);
 
   const redirectToPreview = () => {
     if (eventIsValid) gotoPreview(parsedEvent);


### PR DESCRIPTION
Fikser feil hvor CreateEvent og EditEvent linket til samme preview-path, så når man forsøker å redigere et event blir et nytt event opprettet istedet ([Airtable oppgave](https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/rec417bdideXjMF7l?blocks=hide)).