### PR TITLE
Do not send email when updating old events with test

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -250,7 +250,7 @@ let getEventsSummary =
                        |> Encode.seq
             }
         jsonResult result next context
-        
+
 let getPublicEvents =
     fun (next: HttpFunc) (context: HttpContext) ->
         let result =
@@ -676,19 +676,20 @@ let updateEvent (eventId: Guid) =
                         |> TaskResult.mapError InternalError
                     db.Commit()
 
-                    sendEmailToNewParticipants
-                        oldEvent.Event.MaxParticipants
-                        writeModel.MaxParticipants
-                        oldEventParticipants
-                        updatedEvent
-                        context
+                    if writeModel.StartDate > DateTimeCustom.now() then
+                        sendEmailToNewParticipants
+                            oldEvent.Event.MaxParticipants
+                            writeModel.MaxParticipants
+                            oldEventParticipants
+                            updatedEvent
+                            context
 
-                    sendUpdateEmailToOldParticipants
-                        oldEvent.Event
-                        updatedEvent
-                        oldEventParticipants
-                        writeModel.CancelParticipationUrlTemplate
-                        context
+                        sendUpdateEmailToOldParticipants
+                            oldEvent.Event
+                            updatedEvent
+                            oldEventParticipants
+                            writeModel.CancelParticipationUrlTemplate
+                            context
 
                     let eventAndQuestions = { Event = updatedEvent; NumberOfParticipants = None; Questions = eventQuestions }
                     return Event.encodeEventAndQuestions eventAndQuestions

--- a/Tests/SendEmailOnUpdateEvent.fs
+++ b/Tests/SendEmailOnUpdateEvent.fs
@@ -1,5 +1,6 @@
 namespace Tests.SendMailOnUpdateEvent
 
+open System
 open Tests
 open Xunit
 
@@ -176,4 +177,19 @@ type General(fixture: DatabaseFixture) =
             Assert.Contains(data.UpdatedEvent.OrganizerEmail, actual)
             Assert.False(actual.Contains(data.CreatedEvent.Event.OrganizerName))
             Assert.False(actual.Contains(data.CreatedEvent.Event.OrganizerEmail))
+        }
+
+
+    [<Fact>]
+    member _.``Changing something in old event does not send email``() =
+        task {
+            let! data =
+                init (fun ev ->
+                    { ev with
+                        StartDate = Generator.generateDateTimeCustomPast()
+                        Location = ev.Location + "_NEW_LOCATION" // just to trigger email
+                        OrganizerName = "ORGANIZER_" + Generator.generateName ()
+                        OrganizerEmail = "ORGANIZER_EMAIL_" + Generator.generateEmail () })
+
+            Assert.Equal(data.Message, None)
         }


### PR DESCRIPTION
Vi sendte epost når vi oppdaterte gamle events.
Legger inn sjekk før epost sendes.
La også til ny test