### PR TITLE
Skjuler eksterne arrangementer default - preview

### DIFF
--- a/Frontend/src/components/ViewEventsCards/ViewEventsCardsContainer.tsx
+++ b/Frontend/src/components/ViewEventsCards/ViewEventsCardsContainer.tsx
@@ -33,7 +33,7 @@ const initialFilterOptions: FilterOptions = {
   tidligere: false,
   mine: false,
   eksternt: false,
-  internt: false,
+  internt: true,
 };
 
 export const ViewEventsCardsContainer = () => {


### PR DESCRIPTION
Airtable: https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/recN5TnavHPKrzCNG?blocks=hide

På landingssiden til Skjer vises det nå default kun interne arrangementer.

Fikser samtidig den litt merkelige oppførselen på filteret der hverken "Eksterne" eller "Interne" var huket av, men begge typer arrangementer ble vist:

![image](https://github.com/bekk/bekk-arrangement-svc/assets/6769643/f4a97093-6fcb-4fea-821c-1f7ea88c16e0)

Nå er "Interne" avhuket default.