### PR TITLE
Fjern headings fra CSV-eksport - preview

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -758,13 +758,8 @@ let createCsvString (event: Models.Event) (questions: ParticipantQuestion list) 
         |> List.map (fun q -> formatString q.Question)
         |> String.concat ","
 
-    builder.Append($"{event.Title}\n") |> ignore
-    builder.Append("Påmeldte\n") |> ignore
     builder.Append($"AnsattId,Navn,Epost,Avdeling,{questions}\n") |> ignore
     Seq.iter (createParticipant builder) participants.Attendees
-    if not <| Seq.isEmpty participants.WaitingList then
-        builder.Append("Venteliste\n") |> ignore
-        Seq.iter (createParticipant builder) participants.WaitingList
 
     builder.ToString()
 

--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -760,9 +760,6 @@ let createCsvString (event: Models.Event) (questions: ParticipantQuestion list) 
 
     builder.Append($"AnsattId,Navn,Epost,Avdeling,{questions}\n") |> ignore
     Seq.iter (createParticipant builder) participants.Attendees
-    if not <| Seq.isEmpty participants.WaitingList then
-        builder.Append("Venteliste\n") |> ignore
-        Seq.iter (createParticipant builder) participants.WaitingList
 
     builder.ToString()
 

--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -760,6 +760,9 @@ let createCsvString (event: Models.Event) (questions: ParticipantQuestion list) 
 
     builder.Append($"AnsattId,Navn,Epost,Avdeling,{questions}\n") |> ignore
     Seq.iter (createParticipant builder) participants.Attendees
+    if not <| Seq.isEmpty participants.WaitingList then
+        builder.Append("Venteliste\n") |> ignore
+        Seq.iter (createParticipant builder) participants.WaitingList
 
     builder.ToString()
 


### PR DESCRIPTION
Airtable: https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/recYHS3Bx3qnmFXIO?blocks=hide

**Fjern headings fra CSV-eksport**
Headingene for arrangementstittel og "Påmeldte" gjør at import til for eksempel Airtable ikke greier å automatisk mappe riktig felt til kolonner. Det var også snakk om at vi måtte fjerne "Venteliste"-headingen under vanlig påmeldte, men dette påvirker ikke parsingen siden det ikke forekommer på toppen av CSVen, og kan derfor teknisk sett leve videre. Høres det greit ut? Kan eventuelt vurdre en ny task for å lage valgmulighet for eksport av "deltakere", "venteliste", og "deltakere+venteliste".

Prøvde å sette event-tittelen som filnavn istedenfor guid, men det ble mye rot og kompleksitet (med min F#-kompetanse), i tillegg til at filnavnet må bare bestå et forenklede ASCII-tegn, så eventuelle emojis og spesialtegn må strippes. Så droppet det i denne omgang.

Hvordan CSV-import ser ut i Airtable etter fjerning av topp-headere, men fortsatt har med venteliste:
![bilde](https://github.com/bekk/bekk-arrangement-svc/assets/5686884/4120ba7f-8caa-4c09-8d40-227c3a7caaf4)