### PR TITLE
Fjern endepunkt for /api/events/summary - preview

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -213,20 +213,6 @@ let getFutureEvents (next: HttpFunc) (context: HttpContext) =
         }
     jsonResult result next context
 
-let getEventsSummary =
-    fun (next: HttpFunc) (context: HttpContext) ->
-        let result =
-            taskResult {
-                use db = openConnection context
-                let! events =
-                    Queries.getEventsSummary db
-                    |> TaskResult.mapError InternalError
-                return events
-                       |> Seq.map Event.encodeSummary
-                       |> Encode.seq
-            }
-        jsonResult result next context
-
 let getPublicEvents =
     fun (next: HttpFunc) (context: HttpContext) ->
         let result =
@@ -881,7 +867,6 @@ let routes: HttpHandler =
           GET
           >=> choose [
             route "/api/events/id" >=> getEventIdByShortname
-            route "/api/events/summary" >=> getEventsSummary
             route "/api/events/public" >=> getPublicEvents
             routef "/api/events/%O" getEvent
             routef "/api/events/%s/unfurl" getUnfurlEvent

--- a/Arrangement-Svc/Queries/Queries.fs
+++ b/Arrangement-Svc/Queries/Queries.fs
@@ -104,32 +104,6 @@ let getEventsForForside (email: string) (db: DatabaseContext) =
             return Error ex
     }
 
-let getEventsSummary (db: DatabaseContext) =
-    task {
-        let query =
-            "
-            SELECT E.Id,
-                   E.Title,
-                   E.StartDate,
-                   E.IsExternal
-            FROM Events E
-            WHERE EndDate >= @now
-                AND IsCancelled = 0
-                AND IsHidden = 0
-            "
-
-        let parameters = {|
-            Now = DateTime.Now.Date
-        |}
-
-        try
-            let! result = db.Connection.QueryAsync<Models.EventSummary>(query, parameters, db.Transaction)
-            return Ok result
-        with
-        | ex ->
-            return Error ex
-    }
-
 let getPublicEvents (db: DatabaseContext) =
     task {
         let query =


### PR DESCRIPTION
Airtable: https://airtable.com/appxNXw1b43CSzYhp/tblhytQe93jURxTrn/viwT6LoqYBPJjMBTT/rec3WEueEuMEKc2vK?blocks=hide

Endepunktet var tiltenkt bekk.no og ble laget i februar med PR https://github.com/bekk/bekk-arrangement-svc/pull/135/. Endepunktet ble dog ikke tatt i bruk, og for bekk.no bruker vi nå `/api/events/public`, et nytt endepunkt som kom til senere og bygget videre på `EventSummary`-modellen. Det fører til at vi nå får en nullpointer og HTTP 500-feil ved kall på det gamle endepunktet, fordi DBen ikke henter ut alle påkrevde felter. 

Så det er uansett ikke noe som virker i dag, og så langt Datadog kan se så har det heller ikke vært i bruk.