### PR TITLE
only send email on cancel for participants - preview

### DIFF
--- a/Arrangement-Svc/Service/EmailService.fs
+++ b/Arrangement-Svc/Service/EmailService.fs
@@ -267,8 +267,10 @@ let private sendMailWithCancellationConfirmation event participant context =
     let mail = createCancelledParticipationMailToAttendee event participant
     sendMail mail context
 
-let sendParticipantCancelMails (event: Models.Event) (participant: Models.Participant) (participantAnswers: QuestionAndAnswer list) (personWhoGotIt: ParticipantAndAnswers option) context =
-    sendMailToOrganizerAboutCancellation event participant participantAnswers context
+let sendParticipantCancelMails (event: Models.Event) (participant: Models.Participant) (participantAnswers: QuestionAndAnswer list) (personWhoGotIt: ParticipantAndAnswers option) participantIsAttendee context =
+    if participantIsAttendee then
+        sendMailToOrganizerAboutCancellation event participant participantAnswers context
+
     sendMailWithCancellationConfirmation event participant context
     match personWhoGotIt with
     | Some person -> sendMailToFirstPersonOnWaitingList event person.Participant context

--- a/Tests/DeleteEvent.fs
+++ b/Tests/DeleteEvent.fs
@@ -271,6 +271,27 @@ type DeleteEvent(fixture: DatabaseFixture) =
             Assert.True(List.exists participantIsAvmeldt mailbox)
         }
 
+    [<Fact>]
+    member _.``Deleting a participant on waitinglist should generate 1 email``() =
+        let generatedEvent =
+            TestData.createEvent(fun e ->
+                { e with
+                    HasWaitingList = true
+                    MaxParticipants = Some 0
+                    ParticipantQuestions = []})
+
+        task {
+            let! createdEvent = Helpers.createEventAndGet authenticatedClient generatedEvent
+            let! participant = Helpers.createParticipantAndGet authenticatedClient createdEvent.Event
+
+            emptyDevMailbox()
+            let! _ = Http.deleteParticipantFromEvent clientDifferentUserAdmin createdEvent.Event.Id participant.Email
+            let mailbox = getDevMailbox()
+
+            Assert.Equal(1, List.length mailbox)
+            Assert.True(List.exists isAvmeldtEmail mailbox)
+            Assert.False(List.exists participantIsAvmeldt mailbox)
+        }
 
     [<Fact>]
     member _.``Deleting participant that does not exist returns 404``() =

--- a/Tests/GetEvent.fs
+++ b/Tests/GetEvent.fs
@@ -318,7 +318,7 @@ type GetEvent(fixture: DatabaseFixture) =
         }
 
     [<Fact>]
-    member _.``Admin can can get events and participations for different users``() =
+    member _.``Admin can get events and participations for different users``() =
         task {
             let! response, _ = Http.get clientDifferentUserAdmin "/events-and-participations/0"
             response.EnsureSuccessStatusCode() |> ignore

--- a/Tests/TestHelpers.fs
+++ b/Tests/TestHelpers.fs
@@ -109,6 +109,11 @@ module Helpers =
             | Error e -> return failwith $"Error decoding participations and answers: {e}"
             | Ok result -> return response, result
         }
+    let getParticipantWaitlistSpot client eventId email =
+        task {
+            let! _, response = Http.get client $"/events/{eventId}/participants/{email}/waitinglist-spot"
+            return response
+        }
 
     let getPublicEvents client =
         task {

--- a/Tests/Utils/Generator.fs
+++ b/Tests/Utils/Generator.fs
@@ -43,7 +43,7 @@ let generateDateTimeCustomPast () : DateTimeCustom.DateTimeCustom =
     { Date = generateDatePast ()
       Time = generateTimePast () }
 
-let private generateDateTimeCustomFuture () : DateTimeCustom.DateTimeCustom =
+let generateDateTimeCustomFuture () : DateTimeCustom.DateTimeCustom =
     { Date = generateDateFuture ()
       Time = generateTimeFuture () }
 


### PR DESCRIPTION
Se https://github.com/bekk/bekk-arrangement-svc/pull/193

Løser samme problem ved å bruke den eksisterende `participantIsAttendee`-variabelen. Mindre clean på noen steder, men mindre å synce i databasen uten et `isWaitlisted`-felt og vi slipper en databasemigrering. Usikker på hvilken som er den beste løsningen 🤷