### PR TITLE
Bedre feilmelding når uthenting av påmeldte feiler - preview

### DIFF
--- a/Frontend/src/auth.ts
+++ b/Frontend/src/auth.ts
@@ -63,7 +63,7 @@ function getCurrentState(): string {
   return encodeURIComponent(state);
 }
 
-function getAuth0Url(): string {
+export function getAuth0Url(): string {
   const encodedCallback = encodeURIComponent(
     getApplicationRoot() + '/redirect'
   );

--- a/Frontend/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/Frontend/src/components/ViewEvent/ViewEventContainer.tsx
@@ -210,7 +210,7 @@ export const ViewEventContainer = ({ eventId }: IProps) => {
   };
 
   const canAccessParticipants =
-    editTokenFound || userIsAdmin() || userIsSales();
+    !!editTokenFound || userIsAdmin() || userIsSales();
 
   return (
     <>
@@ -328,9 +328,6 @@ export const ViewEventContainer = ({ eventId }: IProps) => {
               <>
                 <div className={style.attendeesTitleContainer}>
                   <h2 className={style.subHeader}>Påmeldte</h2>
-                  {canAccessParticipants && (
-                    <DownloadExportLink eventId={eventId} />
-                  )}
                 </div>
                 <p>{participantsText}</p>
                 <ViewParticipantsLimited

--- a/Frontend/src/components/ViewEvent/ViewParticipants.module.scss
+++ b/Frontend/src/components/ViewEvent/ViewParticipants.module.scss
@@ -120,3 +120,12 @@
 .modalButton {
   width: 30%;
 }
+
+.badRemoteData {
+  a {
+    color: var(--linkColor)
+  }
+  a:hover {
+    color: var(--linkColorHover)
+  }
+}

--- a/Frontend/src/components/ViewEvent/ViewParticipants.tsx
+++ b/Frontend/src/components/ViewEvent/ViewParticipants.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import style from './ViewParticipants.module.scss';
 import { stringifyEmail } from 'src/types/email';
 import { useEvent, useParticipants } from 'src/hooks/cache';
-import { hasLoaded, isBad } from 'src/remote-data';
+import { hasLoaded, isBad, isUnauthorized } from 'src/remote-data';
 import {
   IParticipant,
   IQuestionAndAnswerViewModel,
@@ -16,6 +16,7 @@ import { useNotification } from '../NotificationHandler/NotificationHandler';
 import { useHistory } from 'react-router';
 import { Plus } from '../Common/Icons/Plus';
 import { RadioButton } from '../Common/RadioButton/RadioButton';
+import { getAuth0Url } from "src/auth";
 
 interface IProps {
   eventId: string;
@@ -26,7 +27,9 @@ export const ViewParticipants = ({ eventId, editToken }: IProps) => {
   const remoteParticipants = useParticipants(eventId, editToken);
 
   if (isBad(remoteParticipants)) {
-    return <div>Det er noe galt med dataen</div>;
+    return isUnauthorized(remoteParticipants)
+      ? <div className={style.badRemoteData}>Du må være autentisert for å se påmeldte deltakere. <a href={getAuth0Url()}>Trykk her</a> for å logge på.</div>
+      : <div>Det har skjedd en feil i bakomliggende systemer. Ta kontakt med #basen på Slack.</div>;
   }
 
   if (!hasLoaded(remoteParticipants)) {

--- a/Frontend/src/components/ViewEvent/ViewParticipantsLimited.tsx
+++ b/Frontend/src/components/ViewEvent/ViewParticipantsLimited.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import style from './ViewParticipants.module.scss';
 import { useParticipants } from 'src/hooks/cache';
-import { hasLoaded, isBad } from 'src/remote-data';
+import { hasLoaded, isBad, isUnauthorized } from 'src/remote-data';
 import { IParticipant } from 'src/types/participant';
 import { Spinner } from 'src/components/Common/Spinner/spinner';
+import { getAuth0Url } from "src/auth";
 
 interface IProps {
   eventId: string;
@@ -18,7 +19,9 @@ export const ViewParticipantsLimited = ({ eventId, editToken }: IProps) => {
   const remoteParticipants = useParticipants(eventId, editToken);
 
   if (isBad(remoteParticipants)) {
-    return <div>Det er noe galt med dataen</div>;
+    return isUnauthorized(remoteParticipants)
+      ? <div className={style.badRemoteData}>Du må være autentisert for å se påmeldte deltakere. <a href={getAuth0Url()}>Trykk her</a> for å logge på.</div>
+      : <div>Det har skjedd en feil i bakomliggende systemer. Ta kontakt med #basen på Slack.</div>;
   }
 
   if (!hasLoaded(remoteParticipants)) {

--- a/Frontend/src/remote-data.ts
+++ b/Frontend/src/remote-data.ts
@@ -31,6 +31,10 @@ export type Bad = {
   userMessage: string;
 };
 
+enum HttpStatusCode {
+  Unauthorized = 401,
+}
+
 export type RemoteData<T> = Ok<T> | Loading | Updating<T> | Bad | NotRequested;
 
 export function isLoading<T>(data: RemoteData<T>): data is Loading {
@@ -55,6 +59,10 @@ export function isNotRequested<T>(data: RemoteData<T>): data is NotRequested {
 
 export function isBad<T>(data: RemoteData<T>): data is Bad {
   return data.status === 'ERROR';
+}
+
+export function isUnauthorized(badRemoteData: Bad): boolean {
+  return badRemoteData.statusCode === HttpStatusCode.Unauthorized;
 }
 
 export function cachedRemoteData<Key extends string, T>() {


### PR DESCRIPTION
Notion: https://www.notion.so/bekks/Det-er-noe-galt-med-dataen-abdb89da74c2409cb9ecbf56faeaf071?pvs=4

Uthenting av deltakerlisten feiler om du har et utgått `userToken` og er inne på et et eksternt arrangement. Grunnen er at eksterne arrangement ikke trigger en re-autentisering, nettopp på grunn av at det er åpent for eksterne og dermed ikke trenger autentisering. Men det skaper problem for admins og arrangører som da heller ikke får opp deltakerlisten, og frem til nå bare har fått meldingen `Det er noe galt med dataen`. Det har løst seg ved å gå til en side som krever gyldig autentisering (for eksempel forsiden), og så gå tilbake. 

Har nå endret feilmeldingene og differensiert på `HTTP 401`-respons (som gjaldt utgått userToken) og øvrige backend-feil:
- HTTP 401: `Du må være autentisert for å se påmeldte deltakere. <a>Trykk her</a> for å logge på.`
- Øvrige feil: `Det har skjedd en feil i bakomliggende systemer. Ta kontakt med #basen på Slack.`

`Trykk her`-lenken er den samme som brukes på øvrige sider, og vil trigge en re-autentisering og ta deg tilbake til samme event.

Før:
![bilde](https://github.com/bekk/bekk-arrangement-svc/assets/5686884/9ba393e1-ad81-43b2-888d-7dbf12ab284e)

Etter:
![bilde](https://github.com/bekk/bekk-arrangement-svc/assets/5686884/9346342d-fa2a-4536-b565-81b5726320c4)