### PR TITLE
limit 4 past events and 8 current or future events for office events

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -236,13 +236,23 @@ let getPublicEvents =
                 let! officeEvents =
                     OfficeEvents.WebApi.getAsList today context
                     
+                let pastOfficeEvents =
+                    List.filter (fun (p: OfficeEvent) -> DateTime.Parse p.StartTime < DateTime.Now) officeEvents
+                    |> Seq.sortByDescending (fun x -> DateTime.Parse x.StartTime)
+                    |> Seq.truncate 4
+                    
+                let currentAndFutureOEvents =
+                    List.filter (fun (p: OfficeEvent) -> DateTime.Parse p.StartTime >= DateTime.Now) officeEvents
+                    |> Seq.sortByDescending (fun x -> DateTime.Parse x.StartTime)
+                    |> Seq.truncate 8
+                    
                 let encodedEvents =
                    events
                    |> Seq.map Event.encodeSkjerEventSummary
                    |> Encode.seq
                    
                 let encodedOfficeEvents =
-                   officeEvents
+                   Seq.append pastOfficeEvents currentAndFutureOEvents
                    |> Seq.map Event.encodeOfficeEventSummary
                    |> Encode.seq
                    


### PR DESCRIPTION
I prod ble listen av office events altfor lang, det gjorde det veldig uryddig i bekk.no lista

Nå henter vi max 4 events fra fortiden og 8 events fra idag og fremtiden.