### PR TITLE
Sender var.task_cpu og var.task_memory inn til aws-deploy

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,6 +35,8 @@ module "aws-deploy" {
   listener_path_patterns = var.listener_path_patterns
   task_image             = var.task_image
   task_image_tag         = var.task_image_tag
+  task_cpu               = var.task_cpu
+  task_memory            = var.task_memory
   task_environment       = var.task_environment
   task_secrets           = var.task_secrets
   enable_tracing         = true


### PR DESCRIPTION
Disse verdiene ble i juni forsøkt økt for produksjon fra standard 256/512 til 1024/2048 (ref. https://github.com/bekk/bekk-arrangement-svc/pull/148), men ble kun satt i `prod.tfvars` og aldri sendt med videre til `aws-deploy`, og har derfor bare fortsatt med default-verdiene 256/512. I prod ligger vi og vaker rundt 25% på CPU og 80-90% på minne, så spesielt for minne har den lite å gå på ved stort trykk - som for eksempel påmelding til Trysil-turen 👀 