### PR TITLE
Slett ubrukte endepunkt - preview

### DIFF
--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -280,20 +280,6 @@ let getPastEvents (next: HttpFunc) (context: HttpContext) =
             }
         jsonResult result next context
 
-let getEventsOrganizedBy (email: string) =
-    fun (next: HttpFunc) (context: HttpContext) ->
-        let result =
-            taskResult {
-                use db = openConnection context
-                let! eventAndQuestions =
-                    Queries.getEventsOrganizedByEmail email db
-                    |> TaskResult.mapError InternalError
-                return
-                    eventAndQuestions
-                    |> List.map Event.encodeEventAndQuestions
-            }
-        jsonResult result next context
-
 let getEventIdByShortnameHttpResult shortname db =
     taskResult {
         let! result =
@@ -883,7 +869,6 @@ let routes: HttpHandler =
             route "/api/events" >=> isAuthenticated >=> getFutureEvents
             route "/api/events/previous" >=> isAuthenticated >=> getPastEvents
             routef "/api/events/forside/%s" (isAuthenticatedf getEventsForForside)
-            routef "/api/events/organizer/%s" (isAuthenticatedf getEventsOrganizedBy)
             routef "/api/events-and-participations/%i" (isAuthenticatedf getEventsAndParticipations)
             routef "/api/events/%O/participants" (isAuthenticatedf getParticipantsForEvent)
             routef "/api/participants/%s/events" (isAuthenticatedf getParticipationsForParticipant)

--- a/Arrangement-Svc/Handlers/Handlers.fs
+++ b/Arrangement-Svc/Handlers/Handlers.fs
@@ -776,20 +776,6 @@ let getWaitinglistSpot (eventId: Guid) (email: string) =
             }
         jsonResult result next context
 
-let getParticipationsForParticipant (email: string) =
-    fun (next: HttpFunc) (context: HttpContext) ->
-        let result =
-            taskResult {
-                use db = openConnection context
-                let! result =
-                    Queries.getParticipationsForParticipant email db
-                    |> TaskResult.mapError InternalError
-                return
-                    result
-                    |> Seq.map Participant.encodeParticipantAndAnswers
-            }
-        jsonResult result next context
-
 let deleteParticipantFromEvent (eventId: Guid) (email: string) =
     fun (next: HttpFunc) (context: HttpContext) ->
         let result =
@@ -871,7 +857,6 @@ let routes: HttpHandler =
             routef "/api/events/forside/%s" (isAuthenticatedf getEventsForForside)
             routef "/api/events-and-participations/%i" (isAuthenticatedf getEventsAndParticipations)
             routef "/api/events/%O/participants" (isAuthenticatedf getParticipantsForEvent)
-            routef "/api/participants/%s/events" (isAuthenticatedf getParticipationsForParticipant)
             routef "/api/office-events/%s" (fun date ->
                 isAuthenticated >=> getOfficeEvents date)
           ]

--- a/Arrangement-Svc/Queries/Queries.fs
+++ b/Arrangement-Svc/Queries/Queries.fs
@@ -320,62 +320,6 @@ let getPastEvents (employeeId: int) (db: DatabaseContext) =
         return! getEventAndParticipantQuestions query numParticipantsQuery parameters db
     }
 
-let getEventsOrganizedByEmail (email: string) (db : DatabaseContext) =
-    task {
-        let query =
-            "
-            SELECT E.Id,
-                   E.Title,
-                   E.Description,
-                   E.Location,
-                   E.City,
-                   E.OrganizerName,
-                   E.OrganizerEmail,
-                   E.StartDate,
-                   E.StartTime,
-                   E.EndDate,
-                   E.EndTime,
-                   E.TargetAudience,
-                   E.MaxParticipants,
-                   E.OrganizerEmail,
-                   E.OpenForRegistrationTime,
-                   E.EditToken,
-                   E.HasWaitingList,
-                   E.IsCancelled,
-                   E.IsExternal,
-                   E.OrganizerId,
-                   E.IsHidden,
-                   E.IsPubliclyAvailable,
-                   E.EventType,
-                   E.CloseRegistrationTime,
-                   E.CustomHexColor,
-                   E.Shortname,
-                   E.Program,
-                   E.Offices,
-                   P.Id,
-                   P.EventId,
-                   P.Question
-            FROM Events E
-                     LEFT JOIN ParticipantQuestions P ON E.Id = P.EventId
-            WHERE E.OrganizerEmail = @email
-            ORDER BY StartDate DESC;
-            "
-        let parameters = {|
-            Email = email
-        |}
-
-        let numParticipantsQuery =
-            "
-            SELECT Id, Count(Id) as NumParticipants
-            FROM EVENTS
-                INNER JOIN Participants P on Events.Id = P.EventId
-            WHERE OrganizerEmail = @email
-            GROUP BY Id
-            "
-
-        return! getEventAndParticipantQuestions query numParticipantsQuery parameters db
-    }
-
 let getEventsOrganizedById (id: int) (db: DatabaseContext) =
     task {
         let query =

--- a/Arrangement-Svc/Queries/Queries.fs
+++ b/Arrangement-Svc/Queries/Queries.fs
@@ -1068,58 +1068,6 @@ let getParticipantsAndAnswersForEvent (eventId: Guid) (db: DatabaseContext) =
             | ex -> return Error ex
     }
 
-let getParticipationsForParticipant email (db: DatabaseContext) =
-    task {
-        let query =
-            "
-            SELECT P.Email,
-                   P.EventId,
-                   P.RegistrationTime,
-                   P.EmployeeId,
-                   P.Name,
-                   P.EmployeeId,
-                   Q.Question,
-                   A.QuestionId,
-                   A.EventId,
-                   A.Email,
-                   A.Answer
-            FROM Participants P
-                LEFT JOIN ParticipantAnswers A on P.Email = A.Email AND P.EventId = A.EventId
-                LEFT JOIN ParticipantQuestions Q ON Q.EventId = P.EventId AND Q.Id = A.QuestionId
-            WHERE P.Email = @email
-            "
-
-        let parameters = {|
-            Email = email
-        |}
-
-        let participants = Dictionary<Models.Participant, Models.QuestionAndAnswer list>()
-
-        try
-            let! _ =
-                db.Connection.QueryAsync(
-                    query,
-                    (fun (participant: Models.Participant) (question: string) (answer: Models.QuestionAndAnswer) ->
-                            if participants.ContainsKey(participant) && not (answer :> obj = null) then
-                                participants[participant] <- participants[participant] @ [{QuestionId = answer.QuestionId; Question = question; Answer = answer.Answer}]
-                            else if not (participants.ContainsKey(participant)) && not (answer :> obj = null) then
-                                participants.Add(participant, [{QuestionId = answer.QuestionId; Question = question; Answer = answer.Answer}])
-                            else
-                                participants.Add(participant, [])
-                        ),
-                    parameters,
-                    splitOn = "Question,QuestionId")
-
-            let result: Models.ParticipantAndAnswers seq =
-                participants
-                |> Seq.fromDict
-                |> Seq.map (fun (x, y) -> { Participant = x; QuestionAndAnswers = y })
-
-            return Ok result
-        with
-            | ex -> return Error ex
-    }
-
 let deleteParticipantFromEvent eventId email (db: DatabaseContext) =
     task {
         let query =

--- a/Arrangement-Svc/Requests.http
+++ b/Arrangement-Svc/Requests.http
@@ -26,10 +26,6 @@ Authorization: Bearer {{token}}
 GET localhost:5000/api/events/previous
 Authorization: Bearer {{token}}
 
-### Get all events by organizer email
-GET localhost:5000/api/events/organizer/<enter organizer email here>
-Authorization: Bearer {{token}}
-
 ### Get all events and participations by employee id
 GET localhost:5000/api/events-and-participations/<enter employee id here>
 Authorization: Bearer {{token}}

--- a/Arrangement-Svc/Requests.http
+++ b/Arrangement-Svc/Requests.http
@@ -18,10 +18,6 @@ Authorization: Bearer {{token}}
 ### Get event by ID
 GET localhost:5000/api/events/<Enter a GUID here>
 
-### Get unfurled event by ID
-GET localhost:5000/api/events/<enter a event id here>/unfurl
-Authorization: Bearer {{token}}
-
 ### Get all future events
 GET localhost:5000/api/events
 Authorization: Bearer {{token}}

--- a/Arrangement-Svc/Requests.http
+++ b/Arrangement-Svc/Requests.http
@@ -42,10 +42,6 @@ Authorization: Bearer {{token}}
 GET localhost:5000/api/events/<enter event id here>/participants/export
 Authorization: Bearer {{token}}
 
-### Get all participations for email
-GET localhost:5000/api/participants/<enter participant email here>/events
-Authorization: Bearer {{token}}
-
 ### Delete participant from event
 DELETE localhost:5000/events/<enter event id here>/participants/<enter participant email here>
 Authorization: Bearer {{token}}

--- a/Tests/GetEvent.fs
+++ b/Tests/GetEvent.fs
@@ -336,15 +336,6 @@ type GetEvent(fixture: DatabaseFixture) =
         }
 
     [<Fact>]
-    member _.``Unauthenticated users cannot get participations for participant``() =
-        let email = Generator.generateEmail ()
-
-        task {
-            let! response, _ = Http.get unauthenticatedClient $"/participants/{email}/events"
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode)
-        }
-
-    [<Fact>]
     member _.``Authenticated users can get participations for participant``() =
         task {
             let email = Generator.generateEmail ()

--- a/Tests/GetEvent.fs
+++ b/Tests/GetEvent.fs
@@ -277,21 +277,6 @@ type GetEvent(fixture: DatabaseFixture) =
             response.EnsureSuccessStatusCode() |> ignore
         }
 
-
-    [<Fact>]
-    member _.``Unauthenticated users cannot get events organized by id``() =
-        task {
-            let! response, _ = Http.get unauthenticatedClient "/events/organizer/0"
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode)
-        }
-
-    [<Fact>]
-    member _.``Authenticated users can get events organized by id``() =
-        task {
-            let! response, _ = Http.get authenticatedClient "/events/organizer/0"
-            response.EnsureSuccessStatusCode() |> ignore
-        }
-
     [<Fact>]
     member _.``Unauthenticated users cannot get events and participations``() =
         task {

--- a/Tests/GetEvent.fs
+++ b/Tests/GetEvent.fs
@@ -338,8 +338,8 @@ type GetEvent(fixture: DatabaseFixture) =
     [<Fact>]
     member _.``Authenticated users can get its own participations``() =
         task {
-            let email = Generator.generateEmail ()
             let mutable eventIds = []
+
             for _ in 0..4 do
                 let event =
                     TestData.createEvent (fun e ->
@@ -352,6 +352,7 @@ type GetEvent(fixture: DatabaseFixture) =
                 let createdEvent = getCreatedEvent createdEvent
                 eventIds <- List.append eventIds [ createdEvent.Event.Id ]
 
+                let email = Generator.generateEmail ()
                 let participant = Generator.generateParticipant email createdEvent.Event
                 let! _ = Helpers.createParticipantForEvent authenticatedClient createdEvent.Event.Id email participant
                 ()

--- a/Tests/GetEvent.fs
+++ b/Tests/GetEvent.fs
@@ -65,17 +65,6 @@ type GetEvent(fixture: DatabaseFixture) =
         }
 
     [<Fact>]
-    member _.``Unfurl events can be seen by anyone``() =
-        let event =
-            TestData.createEvent (fun e -> { e with IsExternal = false })
-
-        task {
-            let! createdEvent = Helpers.createEventAndGet authenticatedClient event
-            let! response, _ = Http.get unauthenticatedClient $"/events/{createdEvent.Event.Id}/unfurl"
-            response.EnsureSuccessStatusCode() |> ignore
-        }
-
-    [<Fact>]
     member _.``Participants can be counted by anyone if event is external``() =
         let event =
             TestData.createEvent (fun e -> { e with IsExternal = true })
@@ -452,4 +441,3 @@ type GetEvent(fixture: DatabaseFixture) =
     
             Assert.True(List.forall (fun (event: EventSummary) -> event.IsPubliclyAvailable = true) body)
         }
-

--- a/Tests/RegisterToEvent.fs
+++ b/Tests/RegisterToEvent.fs
@@ -268,10 +268,10 @@ type RegisterToEvent(fixture: DatabaseFixture) =
                 { generated with ParticipantAnswers = List.mapi (fun index answer -> {answer with Answer = $"Answer {index}" }) generated.ParticipantAnswers }
 
             let! _, _ = Helpers.createParticipantForEvent authenticatedClient createdEvent.Event.Id email participant
-            let! _, body = Helpers.getParticipationsForEvent authenticatedClient email
+            let! _, body = Helpers.getParticipationsAndWaitlist authenticatedClient createdEvent.Event.Id
 
             let actual =
-                body
+                body.Attendees
                 |> List.collect (fun qa -> qa.QuestionAndAnswers)
                 |> List.mapi (fun index qa -> index, qa)
                 |> List.forall (fun (index, qa) -> qa.Answer = $"Answer {index}" && qa.Question = $"Question {index}")
@@ -297,4 +297,3 @@ type RegisterToEvent(fixture: DatabaseFixture) =
             let! response, _ = Helpers.createParticipant authenticatedClient createdEvent.Event
             response.EnsureSuccessStatusCode() |> ignore
         }
-

--- a/Tests/TestHelpers.fs
+++ b/Tests/TestHelpers.fs
@@ -101,12 +101,12 @@ module Helpers =
             | Ok result -> return response, result
         }
 
-    let getParticipationsForEvent client email =
+    let getParticipationsForEmployee client employeeId =
         task {
-            let! response, content = Http.getParticipationsForEvent client email
+            let! response, content = Http.getParticipationsForEmployee client employeeId
 
             match content with
-            | Error e -> return failwith $"Error decoding participations and answers: {e}"
+            | Error e -> return failwith $"Error decoding participations for employee: {e}"
             | Ok result -> return response, result
         }
     let getParticipantWaitlistSpot client eventId email =

--- a/Tests/Utils/Http.fs
+++ b/Tests/Utils/Http.fs
@@ -132,11 +132,11 @@ let getEventIdByShortname (client: HttpClient) (shortname: string) =
     request client url None HttpMethod.Get
 
 
-let getParticipationsForEvent (client: HttpClient) email =
+let getParticipationsForEmployee (client: HttpClient) employeeId =
     requestDecode
         client
-        (participantAndAnswerDecoder |> Decode.list)
-        $"/participants/{email}/events"
+        participationsForEmployeeDecoder
+        $"/events-and-participations/{employeeId}"
         None
         HttpMethod.Get
 

--- a/Tests/Utils/Models.fs
+++ b/Tests/Utils/Models.fs
@@ -65,6 +65,7 @@ let participantAndAnswerDecoder: Decoder<ParticipantAndAnswers> =
     Decode.object (fun get ->
         { Name = get.Required.Field "name" Decode.string
           QuestionAndAnswers = get.Required.Field "questionAndAnswers" (Decode.list questionAndAnswerDecoder) })
+
 type Participations =
     { Participations: string list }
 

--- a/Tests/Utils/Models.fs
+++ b/Tests/Utils/Models.fs
@@ -65,6 +65,15 @@ let participantAndAnswerDecoder: Decoder<ParticipantAndAnswers> =
     Decode.object (fun get ->
         { Name = get.Required.Field "name" Decode.string
           QuestionAndAnswers = get.Required.Field "questionAndAnswers" (Decode.list questionAndAnswerDecoder) })
+type Participations =
+    { Participations: string list }
+
+let eventIdDecoder: Decoder<string> =
+    Decode.object (fun get -> get.Required.Field "eventId" Decode.string)
+
+let participationsForEmployeeDecoder: Decoder<Participations> =
+    Decode.object (fun get ->
+        { Participations = get.Required.Field "participations" (Decode.list eventIdDecoder) })
 
 type ParticipationsAndWaitlist =
     { Attendees: ParticipantAndAnswers list


### PR DESCRIPTION
Notion: https://www.notion.so/bekks/Slette-ubrukte-endepunkt-f5f334dc80ec43d696446ecafee4d2a4?pvs=4

Endepunkter:
- `/api/events/%s/unfurl`: Aner ikke hva denne var god for. Returnerte events på et litt annet format, men ikke i bruk noen steder.
- `/api/events/organizer/%s`: Henter alle events arrangert av epost angitt som argument. Var ikke i bruk, og er dekket av `/api/events-and-participations/%i`-endepunktet, som istedenfor henter ut basert på `employeeId` (kan uansett kun lage events som innlogget).
- `/api/participants/%s/events`: Henter ut alle påmeldte events for e-post angitt som argument. Det er nesten dekt via `/api/events-and-participations/%i`-endepunktet, men siden denne henter basert på e-post og ikke employeeId, får du også med eventer hvor bruker ikke var autentisert (feks. eksterne eventer). Det kan tenkes at dette er "kjekt å ha", men det var altså ikke i bruk noen steder per dags dato, unntatt i noen tester (som jeg skrev om). Fjerner derfor til behovet eventuelt melder seg igjen.

Har sjekket:
- Datadog: Endepunktene ikke har blitt kalt de siste 6 månedene
- Github: Ingen referanse til URLene i noen repo